### PR TITLE
[bugfix] Always sets a device group

### DIFF
--- a/components/CreateSubscriberModal.tsx
+++ b/components/CreateSubscriberModal.tsx
@@ -127,13 +127,13 @@ export default function CreateSubscriberModal({
         setSlices(fetchedSlices);
 
         if (fetchedSlices.length === 1) {
+          console.log("We are logging here 0 ");
           const singleSlice = fetchedSlices[0];
           setSelectedSlice(singleSlice.SliceName);
+          console.log("Slice: ", singleSlice);
           if (singleSlice["site-device-group"]) {
             setDeviceGroupOptions(singleSlice["site-device-group"]);
-            if (singleSlice["site-device-group"].length === 1) {
-              setSelectedDeviceGroup(singleSlice["site-device-group"][0]);
-            }
+            setSelectedDeviceGroup(singleSlice["site-device-group"][0]);
           } else {
             setDeviceGroupOptions([]);
           }


### PR DESCRIPTION
# Description

Fixes a bug where subscriber creation would fail whenever the user was not changing the device group selected in the modal.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
