### PR TITLE
[bug fix] Uses bps instead of Mbps for webui communication

### DIFF
--- a/components/DeviceGroupModal.tsx
+++ b/components/DeviceGroupModal.tsx
@@ -90,14 +90,16 @@ export default function DeviceGroupModal({
       setApiError("Please select a value for the downstream bitrate.");
       return;
     }
+    const MBRUpstreamBps = MBRUpstreamMbps * 1000000;
+    const MBRDownstreamBps = MBRDownstreamMbps * 1000000;
     try {
       await createDeviceGroup({
         name: name,
         ueIpPool: ueIpPool,
         dns: dns,
         mtu: mtu,
-        MBRUpstreamMbps: MBRUpstreamMbps,
-        MBRDownstreamMbps: MBRDownstreamMbps,
+        MBRUpstreamBps: MBRUpstreamBps,
+        MBRDownstreamBps: MBRDownstreamBps,
         networkSliceName: networkSliceName,
       });
       onDeviceGroupCreated();

--- a/utils/createDeviceGroup.tsx
+++ b/utils/createDeviceGroup.tsx
@@ -3,8 +3,8 @@ interface DeviceGroupArgs {
   ueIpPool: string;
   dns: string;
   mtu: number;
-  MBRUpstreamMbps: number;
-  MBRDownstreamMbps: number;
+  MBRUpstreamBps: number;
+  MBRDownstreamBps: number;
   networkSliceName: string;
 }
 
@@ -13,8 +13,8 @@ export const createDeviceGroup = async ({
   ueIpPool,
   dns,
   mtu,
-  MBRUpstreamMbps,
-  MBRDownstreamMbps,
+  MBRUpstreamBps,
+  MBRDownstreamBps,
   networkSliceName,
 }: DeviceGroupArgs) => {
   const deviceGroupData = {
@@ -26,9 +26,9 @@ export const createDeviceGroup = async ({
       "dns-primary": dns,
       mtu: mtu,
       "ue-dnn-qos": {
-        "dnn-mbr-uplink": MBRUpstreamMbps,
-        "dnn-mbr-downlink": MBRDownstreamMbps,
-        "bitrate-unit": "Mbps",
+        "dnn-mbr-uplink": MBRUpstreamBps,
+        "dnn-mbr-downlink": MBRDownstreamBps,
+        "bitrate-unit": "bps",
         "traffic-class": {
           name: "platinum",
           arp: 6,


### PR DESCRIPTION
# Description

Uses bps instead of Mbps for webui communication. Using Mbps provided inconsistent responses from webui where when users were added to a device group, the bitrate return value would change.

Fixes #113 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
