### PR TITLE
[feat] Adds confirmation modal when deleting network slice

### DIFF
--- a/app/network-configuration/page.tsx
+++ b/app/network-configuration/page.tsx
@@ -9,7 +9,7 @@ import {
 } from "@canonical/react-components";
 import { deleteNetworkSlice } from "@/utils/deleteNetworkSlice";
 import { getNetworkSlices } from "@/utils/getNetworkSlices";
-import NetworkSliceModal from "@/components/NetworkSliceModal";
+import CreateNetworkSliceModal from "@/components/CreateNetworkSliceModal";
 import NetworkSliceEmptyState from "@/components/NetworkSliceEmptyState";
 import { NetworkSlice } from "@/components/types";
 import { NetworkSliceTable } from "@/components/NetworkSliceTable";
@@ -17,8 +17,10 @@ import { NetworkSliceTable } from "@/components/NetworkSliceTable";
 export default function NetworkConfiguration() {
   const [loading, setLoading] = useState(true);
   const [networkSlices, setNetworkSlices] = useState<NetworkSlice[]>([]);
-  const [isNetworkSliceModalVisible, setIsNetworkSliceModalVisible] =
-    useState(false);
+  const [
+    isCreateNetworkSliceModalVisible,
+    setisCreateNetworkSliceModalVisible,
+  ] = useState(false);
   const [isDeleteNetworkSliceModalOpen, setIsDeleteNetworkSliceModalOpen] =
     useState(false);
   const [selectedSliceName, setSelectedSliceName] = useState<string | null>(
@@ -35,8 +37,8 @@ export default function NetworkConfiguration() {
     fetchDataAndUpdateState();
   }, []);
 
-  const toggleNetworkSliceModal = () =>
-    setIsNetworkSliceModalVisible((prev) => !prev);
+  const toggleCreateNetworkSliceModal = () =>
+    setisCreateNetworkSliceModalVisible((prev) => !prev);
 
   const openDeleteConfirmationModal = (sliceName: string) => {
     setSelectedSliceName(sliceName);
@@ -52,7 +54,8 @@ export default function NetworkConfiguration() {
     }
   };
 
-  const closeDeleteModal = () => setIsDeleteNetworkSliceModalOpen(false);
+  const closeDeleteNetworkSliceModal = () =>
+    setIsDeleteNetworkSliceModalOpen(false);
 
   if (loading) return <div>Loading...</div>;
 
@@ -68,23 +71,12 @@ export default function NetworkConfiguration() {
     <div>
       <Row>
         <Col size={6}>
-          {isDeleteNetworkSliceModalOpen && (
-            <ConfirmationModal
-              title="Confirm delete"
-              confirmButtonLabel="Delete"
-              onConfirm={handleConfirmDelete}
-              close={closeDeleteModal}
-            >
-              <p>
-                {`This will permanently delete the network slice "${selectedSliceName}".`}
-                <br />
-                You cannot undo this action.
-              </p>
-            </ConfirmationModal>
-          )}
           <h2>Network Slices</h2>
           <div className="u-align--right">
-            <Button appearance="positive" onClick={toggleNetworkSliceModal}>
+            <Button
+              appearance="positive"
+              onClick={toggleCreateNetworkSliceModal}
+            >
               Create
             </Button>
           </div>
@@ -104,11 +96,25 @@ export default function NetworkConfiguration() {
           ))}
         </Col>
       </Row>
-      {isNetworkSliceModalVisible && (
-        <NetworkSliceModal
-          toggleModal={toggleNetworkSliceModal}
+      {isCreateNetworkSliceModalVisible && (
+        <CreateNetworkSliceModal
+          toggleModal={toggleCreateNetworkSliceModal}
           onSliceCreated={fetchDataAndUpdateState}
         />
+      )}
+      {isDeleteNetworkSliceModalOpen && (
+        <ConfirmationModal
+          title="Confirm delete"
+          confirmButtonLabel="Delete"
+          onConfirm={handleConfirmDelete}
+          close={closeDeleteNetworkSliceModal}
+        >
+          <p>
+            {`This will permanently delete the network slice "${selectedSliceName}".`}
+            <br />
+            You cannot undo this action.
+          </p>
+        </ConfirmationModal>
       )}
     </div>
   );

--- a/app/network-configuration/page.tsx
+++ b/app/network-configuration/page.tsx
@@ -1,6 +1,12 @@
 "use client";
 import React, { useState, useEffect } from "react";
-import { Row, Col, Button, Card } from "@canonical/react-components";
+import {
+  Row,
+  Col,
+  Button,
+  Card,
+  ConfirmationModal,
+} from "@canonical/react-components";
 import { deleteNetworkSlice } from "@/utils/deleteNetworkSlice";
 import { getNetworkSlices } from "@/utils/getNetworkSlices";
 import NetworkSliceModal from "@/components/NetworkSliceModal";
@@ -10,16 +16,17 @@ import { NetworkSliceTable } from "@/components/NetworkSliceTable";
 
 export default function NetworkConfiguration() {
   const [loading, setLoading] = useState(true);
-  const [isNetworkSliceModalVisible, setisNetworkSliceModalVisible] =
-    useState(false);
   const [networkSlices, setNetworkSlices] = useState<NetworkSlice[]>([]);
-
-  const toggleNetworkSliceModal = () => {
-    setisNetworkSliceModalVisible(!isNetworkSliceModalVisible);
-  };
+  const [isNetworkSliceModalVisible, setIsNetworkSliceModalVisible] =
+    useState(false);
+  const [isDeleteNetworkSliceModalOpen, setIsDeleteNetworkSliceModalOpen] =
+    useState(false);
+  const [selectedSliceName, setSelectedSliceName] = useState<string | null>(
+    null,
+  );
 
   const fetchDataAndUpdateState = async () => {
-    const slices: NetworkSlice[] = await getNetworkSlices();
+    const slices = await getNetworkSlices();
     setNetworkSlices(slices);
     setLoading(false);
   };
@@ -28,14 +35,26 @@ export default function NetworkConfiguration() {
     fetchDataAndUpdateState();
   }, []);
 
-  const handleDeleteNetworkSlice = async (sliceName: string) => {
-    await deleteNetworkSlice(sliceName);
-    fetchDataAndUpdateState();
+  const toggleNetworkSliceModal = () =>
+    setIsNetworkSliceModalVisible((prev) => !prev);
+
+  const openDeleteConfirmationModal = (sliceName: string) => {
+    setSelectedSliceName(sliceName);
+    setIsDeleteNetworkSliceModalOpen(true);
   };
 
-  if (loading) {
-    return <div>Loading...</div>;
-  }
+  const handleConfirmDelete = async () => {
+    if (selectedSliceName) {
+      await deleteNetworkSlice(selectedSliceName);
+      setSelectedSliceName(null);
+      setIsDeleteNetworkSliceModalOpen(false);
+      fetchDataAndUpdateState();
+    }
+  };
+
+  const closeDeleteModal = () => setIsDeleteNetworkSliceModalOpen(false);
+
+  if (loading) return <div>Loading...</div>;
 
   if (!networkSlices.length) {
     return (
@@ -49,20 +68,34 @@ export default function NetworkConfiguration() {
     <div>
       <Row>
         <Col size={6}>
+          {isDeleteNetworkSliceModalOpen && (
+            <ConfirmationModal
+              title="Confirm delete"
+              confirmButtonLabel="Delete"
+              onConfirm={handleConfirmDelete}
+              close={closeDeleteModal}
+            >
+              <p>
+                {`This will permanently delete the network slice "${selectedSliceName}".`}
+                <br />
+                You cannot undo this action.
+              </p>
+            </ConfirmationModal>
+          )}
           <h2>Network Slices</h2>
           <div className="u-align--right">
-            <Button appearance={"positive"} onClick={toggleNetworkSliceModal}>
+            <Button appearance="positive" onClick={toggleNetworkSliceModal}>
               Create
             </Button>
           </div>
           {networkSlices.map((slice) => (
             <Card key={slice.SliceName} title={slice.SliceName}>
-              {<NetworkSliceTable sliceName={slice.SliceName} />}
+              <NetworkSliceTable sliceName={slice.SliceName} />
               <hr />
               <div className="u-align--right">
                 <Button
-                  appearance={"negative"}
-                  onClick={() => handleDeleteNetworkSlice(slice.SliceName)}
+                  appearance="negative"
+                  onClick={() => openDeleteConfirmationModal(slice.SliceName)}
                 >
                   Delete
                 </Button>

--- a/components/CreateNetworkSliceModal.tsx
+++ b/components/CreateNetworkSliceModal.tsx
@@ -25,7 +25,7 @@ interface GnbItem {
   tac: number;
 }
 
-export default function NetworkSliceModal({
+export default function CreateNetworkSliceModal({
   toggleModal,
   onSliceCreated,
 }: NetworkSliceModalProps) {

--- a/components/NetworkSliceEmptyState.tsx
+++ b/components/NetworkSliceEmptyState.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState } from "react";
-import NetworkSliceModal from "@/components/NetworkSliceModal";
+import CreateNetworkSliceModal from "@/components/CreateNetworkSliceModal";
 import { Button, Row, Col, Strip } from "@canonical/react-components";
 
 interface NetworkSliceEmptyStateProps {
@@ -42,7 +42,7 @@ export default function NetworkSliceEmptyState({
       </table>
 
       {isModalVisible && (
-        <NetworkSliceModal
+        <CreateNetworkSliceModal
           toggleModal={toggleModal}
           onSliceCreated={handleSliceCreated}
         />


### PR DESCRIPTION
# Description

Adds a confirmation modal when deleting network slice.

![image](https://github.com/canonical/sdcore-nms/assets/18486508/fed5d9c6-c471-47f9-a494-e9530fe25cfd)


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
