### PR TITLE
chore: Moves types to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "version": "0.2.0",
       "dependencies": {
         "@canonical/react-components": "^0.47.0",
-        "@types/node": "20.8.2",
-        "@types/react": "18.2.21",
-        "@types/react-dom": "18.2.7",
         "autoprefixer": "10.4.16",
         "eslint": "8.50.0",
         "eslint-config-next": "13.5.4",
@@ -27,6 +24,9 @@
         "vanilla-framework": "^4.0.0"
       },
       "devDependencies": {
+        "@types/node": "20.8.2",
+        "@types/react": "18.2.21",
+        "@types/react-dom": "18.2.7",
         "prettier": "^3.0.2",
         "prettier-plugin-tailwindcss": "^0.5.0"
       }
@@ -452,7 +452,8 @@
     "node_modules/@types/node": {
       "version": "20.8.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.2.tgz",
-      "integrity": "sha512-Vvycsc9FQdwhxE3y3DzeIxuEJbWGDsnrxvMADzTDF/lcdR9/K+AQIeAghTQsHtotg/q0j3WEOYS/jQgSdWue3w=="
+      "integrity": "sha512-Vvycsc9FQdwhxE3y3DzeIxuEJbWGDsnrxvMADzTDF/lcdR9/K+AQIeAghTQsHtotg/q0j3WEOYS/jQgSdWue3w==",
+      "dev": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -473,6 +474,7 @@
       "version": "18.2.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
       "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@canonical/react-components": "^0.47.0",
-    
     "autoprefixer": "10.4.16",
     "eslint": "8.50.0",
     "eslint-config-next": "13.5.4",
@@ -29,7 +28,7 @@
     "prettier": "^3.0.2",
     "prettier-plugin-tailwindcss": "^0.5.0",
     "@types/node": "20.8.2",
-    "@types/react": "18.2.21",
+    "@types/react": "18.2.22",
     "@types/react-dom": "18.2.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
   },
   "dependencies": {
     "@canonical/react-components": "^0.47.0",
-    "@types/node": "20.8.2",
-    "@types/react": "18.2.21",
-    "@types/react-dom": "18.2.7",
+    
     "autoprefixer": "10.4.16",
     "eslint": "8.50.0",
     "eslint-config-next": "13.5.4",
@@ -29,6 +27,9 @@
   },
   "devDependencies": {
     "prettier": "^3.0.2",
-    "prettier-plugin-tailwindcss": "^0.5.0"
+    "prettier-plugin-tailwindcss": "^0.5.0",
+    "@types/node": "20.8.2",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7"
   }
 }


### PR DESCRIPTION
# Description

This change will solve the issue preventing from bumping to the new version of "types" as done in [this renovate PR](https://github.com/canonical/sdcore-nms/pull/94).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
