### PR TITLE
chore: Adds pebble service to rockcraft

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -8,15 +8,33 @@ license: Apache-2.0
 platforms:
   amd64:
 
-parts:
-  node:  # FIXME: Node should be installed using `stage-snap`. Bug: https://github.com/canonical/rockcraft/issues/307
-    plugin: nil
-    override-build: |
-      curl -s "https://nodejs.org/dist/v18.16.1/node-v18.16.1-linux-x64.tar.gz" | tar --strip-components=1 -xzf - -C "${CRAFT_PART_INSTALL}"
+package-repositories:
+  - type: apt
+    components: [main]
+    priority: always
+    suites: [nodistro]
+    key-id: 6F71F525282841EEDAF851B42F59B5F99B1BE0B4
+    key-server: https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
+    url: https://deb.nodesource.com/node_18.x
 
-  frontend:
+services:
+  nms:
+    command: npm run start
+    override: replace
+    startup: enabled
+    working-dir: app
+    environment:
+      UPF_CONFIG_PATH: /etc/upf/upf.json
+      GNB_CONFIG_PATH: /etc/gnb/gnb.json
+      WEBUI_ENDPOINT: http://10.1.182.9:5000
+
+parts:
+
+  nms:
     plugin: nil
     source: .
+    stage-packages:
+      - nodejs
     build-snaps:
       - node/18/stable
     override-build: |
@@ -27,4 +45,4 @@ parts:
       
       cp -r .next ${CRAFT_PART_INSTALL}/app/
       cp -r node_modules ${CRAFT_PART_INSTALL}/app/
-      cp package*.json ${CRAFT_PART_INSTALL}/app/
+      cp package.json ${CRAFT_PART_INSTALL}/app/


### PR DESCRIPTION
# Description

This PR improves the rock in various way:
- Adds pebble service for nms
- Uses the same nodejs source for build and stage instead of having a ppa in a snap. This source is now the official ppa repo with gpg key validation instead of being a binary. Note that we can't use the snap because of [this bug](https://github.com/canonical/rockcraft/issues/307) in rockcraft. This removes the need for the "node" part.
- Removes unnecessary stage of package-lock.json

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
