### PR TITLE
fix: Removes typo in CI docker push

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,5 +54,4 @@ jobs:
 
       - name: Push to github package
         run: |
-
-          docker push ghcr.io/canonical/${{env.image_name}}:${{env.version}}"
+          docker push ghcr.io/canonical/${{env.image_name}}:${{env.version}}


### PR DESCRIPTION
# Description

PR #197 introduced an unnecessary `"` at the end of the `docker push` command which caused failures in publishing the NMS image to ghcr. This PR fixes this issue.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
