### PR TITLE
fix: Creates a default device group when creating a new network slice

### DIFF
--- a/utils/createNetworkSlice.tsx
+++ b/utils/createNetworkSlice.tsx
@@ -25,7 +25,7 @@ export const createNetworkSlice = async ({
       sst: "1",
       sd: "010203",
     },
-    "site-device-group": null,
+    "site-device-group": ["default"],
     "site-info": {
       "site-name": "demo",
       plmn: {
@@ -40,8 +40,31 @@ export const createNetworkSlice = async ({
     },
   };
 
+  const deviceGroupData = {
+    "site-info": "demo",
+    "ip-domain-name": "pool1",
+    "ip-domain-expanded": {
+      dnn: "internet",
+      "ue-ip-pool": "172.250.1.0/16",
+      "dns-primary": "8.8.8.8",
+      mtu: 1600,
+      "ue-dnn-qos": {
+        "dnn-mbr-uplink": 200 * 1000000,
+        "dnn-mbr-downlink": 20 * 1000000,
+        "bitrate-unit": "bps",
+        "traffic-class": {
+          name: "platinum",
+          arp: 6,
+          pdb: 300,
+          pelr: 6,
+          qci: 8,
+        },
+      },
+    },
+  };
+
   try {
-    const response = await fetch(`/api/network-slice/${name}`, {
+    const networksliceResponse = await fetch(`/api/network-slice/${name}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -49,19 +72,38 @@ export const createNetworkSlice = async ({
       body: JSON.stringify(sliceData),
     });
 
-    if (!response.ok) {
-      const result = await response.json();
+    if (!networksliceResponse.ok) {
+      const result = await networksliceResponse.json();
       if (result.error) {
         throw new Error(result.error);
       }
       debugger;
-      throw new Error(`Error creating network. Error code: ${response.status}`);
+      throw new Error(
+        `Error creating network. Error code: ${networksliceResponse.status}`,
+      );
     }
 
-    return response.json();
+    const devicegroupResponse = await fetch(`/api/device-group/${name}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(deviceGroupData),
+    });
+
+    if (!devicegroupResponse.ok) {
+      throw new Error(
+        `Error creating device group. Error code: ${devicegroupResponse.status}`,
+      );
+    }
+
+    return networksliceResponse.json();
   } catch (error: unknown) {
     console.error(error);
-    const details = error instanceof Error ? error.message : "Failed to configure the network.";
+    const details =
+      error instanceof Error
+        ? error.message
+        : "Failed to configure the network.";
     throw new Error(details);
   }
 };


### PR DESCRIPTION
# Description

This PR fixes an issue with the NMS where creating a network slice, a device group and a subscriber (in this order) would not work because of a bug in the upstream project (https://github.com/omec-project/webconsole/issues/89). Here we introduce a workaround where we specify a "default" device group when we create the network slice and then create this device group. This really is a workaround and should be reverted once the upstream bug is addressed.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
