### PR TITLE
feat: Adds total number of device groups

### DIFF
--- a/components/NetworkSliceTable.tsx
+++ b/components/NetworkSliceTable.tsx
@@ -3,10 +3,7 @@ import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import ExpandMoreOutlinedIcon from "@mui/icons-material/ExpandMoreOutlined";
 
 import React, { useState } from "react";
-import {
-  Button,
-  MainTable,
-} from "@canonical/react-components";
+import { Button, MainTable } from "@canonical/react-components";
 import DeviceGroupModal from "@/components/DeviceGroupModal";
 import { queryKeys } from "@/utils/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
@@ -26,8 +23,12 @@ export const NetworkSliceTable: React.FC<NetworkSliceTableProps> = ({
   const toggleModal = () => setIsModalVisible(!isModalVisible);
 
   const handleDeviceGroupCreated = async () => {
-    await queryClient.invalidateQueries({ queryKey: [queryKeys.networkSlices] });
-    await queryClient.invalidateQueries({ queryKey: [queryKeys.allDeviceGroups, slice.SliceName] });
+    await queryClient.invalidateQueries({
+      queryKey: [queryKeys.networkSlices],
+    });
+    await queryClient.invalidateQueries({
+      queryKey: [queryKeys.allDeviceGroups, slice.SliceName],
+    });
   };
 
   return (
@@ -97,7 +98,12 @@ export const NetworkSliceTable: React.FC<NetworkSliceTableProps> = ({
           },
           {
             columns: [
-              { content: "Device Groups" },
+              {
+                content: `Device Groups (${
+                  !slice["site-device-group"] ||
+                  slice["site-device-group"].length
+                })`,
+              },
               {
                 content: (
                   <div className="u-align--right">
@@ -127,14 +133,21 @@ export const NetworkSliceTable: React.FC<NetworkSliceTableProps> = ({
                     >
                       <ExpandMoreOutlinedIcon
                         fontSize="small"
-                        style={{ color: "#666", transform: isExpanded ? "rotate(180deg)" : "rotate(0)" }}
+                        style={{
+                          color: "#666",
+                          transform: isExpanded
+                            ? "rotate(180deg)"
+                            : "rotate(0)",
+                        }}
                       />
                     </Button>
                   </div>
                 ),
               },
             ],
-            expandedContent: <NetworkSliceGroups slice={slice} isExpanded={isExpanded} />,
+            expandedContent: (
+              <NetworkSliceGroups slice={slice} isExpanded={isExpanded} />
+            ),
             expanded: isExpanded,
             key: `device-groups-${slice.SliceName}`,
           },


### PR DESCRIPTION
# Description

Just like we display the total number of network slices and subscribers in parenthesis (example: `Network Slices (3)`), we now do the same for device groups.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
