### PR TITLE
chore: Uses image from next/image

### DIFF
--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -1,10 +1,12 @@
 import React, { FC } from "react";
 
+import Image from "next/image";
+
 const Logo: FC = () => {
   return (
     <a className="logo" href="/">
       <div className="logo-tag">
-        <img
+        <Image
           src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg"
           alt="circle of friends"
           className="logo-image"


### PR DESCRIPTION
# Description

Uses image from next/image instead of img. This is to address the following warning given by next when building the NMS:

```
./components/Logo.tsx
7:9  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
