### PR TITLE
fix: Deletes subscribers using `imsi-` prefix

### DIFF
--- a/utils/deleteSubscriber.tsx
+++ b/utils/deleteSubscriber.tsx
@@ -69,8 +69,7 @@ export const deleteSubscriber = async (imsi: string) => {
         }
       }
     }
-
-    const response = await fetch(`/api/subscriber/${imsi}`, {
+    const response = await fetch(`/api/subscriber/imsi-${imsi}`, {
       method: "DELETE",
     });
 


### PR DESCRIPTION
# Description

We used to delete subscribers by calling `subscriber/<imsi>` which would partially work but a subscriber with no name would remain and would result in a "ghost" subscriber in the subscriber table. The right way to delete subscribers is by calling `subscriber/imsi-<imsi>`. 

Fixes #201

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
