### PR TITLE
feat: Bumps node to v20 in rock

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -8,15 +8,6 @@ license: Apache-2.0
 platforms:
   amd64:
 
-package-repositories:
-  - type: apt
-    components: [main]
-    priority: always
-    suites: [nodistro]
-    key-id: 6F71F525282841EEDAF851B42F59B5F99B1BE0B4
-    key-server: https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
-    url: https://deb.nodesource.com/node_18.x
-
 services:
   nms:
     command: npm run start
@@ -33,10 +24,10 @@ parts:
   nms:
     plugin: nil
     source: .
-    stage-packages:
-      - nodejs
+    stage-snaps:
+      - node/20/stable
     build-snaps:
-      - node/18/stable
+      - node/20/stable
     override-build: |
       mkdir -p ${CRAFT_PART_INSTALL}/app
       


### PR DESCRIPTION
# Description

NodeJS 20 is now LTS. This PR bumps the node dependency in the rock from 18 to 20. We also use the same source for both the stage and build environments (the node snap).

## Reference
- https://nodejs.org/en

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
