### PR TITLE
fix: NS deletes subscribers that belong to other NS

### DIFF
--- a/utils/createNetworkSlice.tsx
+++ b/utils/createNetworkSlice.tsx
@@ -12,8 +12,6 @@ interface CreateNetworkSliceArgs {
   gnbList: GnbItem[];
 }
 
-const DeviceGroupName = "default";
-
 export const createNetworkSlice = async ({
   name,
   mcc,
@@ -22,12 +20,13 @@ export const createNetworkSlice = async ({
   upfPort,
   gnbList,
 }: CreateNetworkSliceArgs) => {
+  const deviceGroupName = `${name}-default`;
   const sliceData = {
     "slice-id": {
       sst: "1",
       sd: "010203",
     },
-    "site-device-group": [DeviceGroupName],
+    "site-device-group": [deviceGroupName],
     "site-info": {
       "site-name": "demo",
       plmn: {
@@ -86,7 +85,7 @@ export const createNetworkSlice = async ({
     }
 
     const devicegroupResponse = await fetch(
-      `/api/device-group/${DeviceGroupName}`,
+      `/api/device-group/${deviceGroupName}`,
       {
         method: "POST",
         headers: {


### PR DESCRIPTION
# Description

This is a fix for https://github.com/canonical/sdcore-nms/issues/222

After https://github.com/canonical/sdcore-nms/pull/200 we create a `default` Device Group when we create a NS.

The same name was used for every NS created, which resulted in only one Device Group. 

When we deleted a NS, the `default` Device Group was deleted as well, resulting in the delete of all the subscribers associated to this `default` Device Group, even if they belonged to another NS. 

A fix for this is to use the name of the NS in the name of the default Device Group created at the NS creation time:
`deviceGroupName = ${name}-default`. This way, we can guarantee that the Device Group name is unique at the moment.

There is a task in the backlog  called: "Validate that device group doesn't yet exist before creating it". Which will help prevent this case in the future.

Note: the creation of a default Device Group is a temporary workaround for a known bug (https://github.com/omec-project/webconsole/issues/89)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
