### PR TITLE
fix: Uses default mtu of 1460

### DIFF
--- a/utils/createNetworkSlice.tsx
+++ b/utils/createNetworkSlice.tsx
@@ -50,8 +50,8 @@ export const createNetworkSlice = async ({
       "dns-primary": "8.8.8.8",
       mtu: 1460,
       "ue-dnn-qos": {
-        "dnn-mbr-uplink": 200 * 1000000,
-        "dnn-mbr-downlink": 20 * 1000000,
+        "dnn-mbr-uplink": 20 * 1000000,
+        "dnn-mbr-downlink": 200 * 1000000,
         "bitrate-unit": "bps",
         "traffic-class": {
           name: "platinum",

--- a/utils/createNetworkSlice.tsx
+++ b/utils/createNetworkSlice.tsx
@@ -48,7 +48,7 @@ export const createNetworkSlice = async ({
       dnn: "internet",
       "ue-ip-pool": "172.250.1.0/16",
       "dns-primary": "8.8.8.8",
-      mtu: 1600,
+      mtu: 1460,
       "ue-dnn-qos": {
         "dnn-mbr-uplink": 200 * 1000000,
         "dnn-mbr-downlink": 20 * 1000000,


### PR DESCRIPTION
# Description

Uses default mtu of 1460 instead of 1600 and transposes uplink/downlink bitrates. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
