### PR TITLE
fix: Include pages directory in final image

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -33,7 +33,8 @@ parts:
       
       npm ci
       npm run build
-      
+
       cp -r .next ${CRAFT_PART_INSTALL}/app/
       cp -r node_modules ${CRAFT_PART_INSTALL}/app/
       cp package.json ${CRAFT_PART_INSTALL}/app/
+      cp -r pages ${CRAFT_PART_INSTALL}/app/


### PR DESCRIPTION
# Description

The `/pages` directory was not copied over in the final ROCK image. This directory contains the swagger definitions needed to display the API documentation.

Fixes #229 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
