### PR TITLE
fix: set MTU as number instead of string in device group creation

### DIFF
--- a/components/DeviceGroupModal.tsx
+++ b/components/DeviceGroupModal.tsx
@@ -39,14 +39,14 @@ const DeviceGroupModal = ({
   const [apiError, setApiError] = useState<string | null>(null);
 
   const DeviceGroupSchema = Yup.object().shape({
-    name: Yup.string().min(1).max(20, "Name should not exceed 20 characters")
+    name: Yup.string().min(1).max(20, "Name should not exceed 20 characters.")
       .matches(/^[a-zA-Z0-9-_]+$/, { message: 'Only alphanumeric characters, dashes and underscores.'})
       .required("Name is required."),
-    ueIpPool: Yup.string().required("IP is required").matches(regexpCIDR, "Invalid IP Address Pool"),
-    dns: Yup.string().required("IP is required").matches(regexIp, "Invalid IP Address"),
-    mtu: Yup.number().min(1200).max(65535).required("Invalid MTU"),
-    MBRDownstreamMbps: Yup.number().min(0).max(1000000).required("Value should be between 0 and 1,000,000"),
-    MBRUpstreamMbps: Yup.number().min(0).max(1000000).required("Value should be between 0 and 1,000,000"),
+    ueIpPool: Yup.string().required("IP is required").matches(regexpCIDR, "Invalid IP Address Pool."),
+    dns: Yup.string().required("IP is required").matches(regexIp, "Invalid IP Address."),
+    mtu: Yup.number().min(1200).max(65535).required("Invalid MTU."),
+    MBRDownstreamMbps: Yup.number().min(0).max(1000000).required("Value should be between 0 and 1,000,000."),
+    MBRUpstreamMbps: Yup.number().min(0).max(1000000).required("Value should be between 0 and 1,000,000."),
   });
 
   const formik = useFormik<DeviceGroupValues>({
@@ -134,10 +134,10 @@ const DeviceGroupModal = ({
           error={formik.touched.dns ? formik.errors.dns : null}
         />
         <Input
-          type="text"
+          type="number"
           id="mtu"
           label="MTU"
-          defaultValue={"1460"}
+          defaultValue={1460}
           stacked
           required
           {...formik.getFieldProps("mtu")}


### PR DESCRIPTION
# Description

Fix for https://github.com/canonical/sdcore-nms/issues/236

MTU should be a number, not a string.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
