### PR TITLE
fix: don't set a selected device group when there is more than 1 available

### DIFF
--- a/components/CreateSubscriberModal.tsx
+++ b/components/CreateSubscriberModal.tsx
@@ -19,7 +19,7 @@ interface SubscriberValues {
   opc: string;
   key: string;
   sequenceNumber: string;
-  selectedSlice: string | null;
+  selectedSlice: string;
   deviceGroup: string;
 }
 
@@ -58,7 +58,7 @@ const CreateSubscriberModal = ({ toggleModal }: Props) => {
       opc: "",
       key: "",
       sequenceNumber: "",
-      selectedSlice: null,
+      selectedSlice: "",
       deviceGroup: "",
     },
     validationSchema: SubscriberSchema,
@@ -100,8 +100,6 @@ const CreateSubscriberModal = ({ toggleModal }: Props) => {
       selectedSlice["site-device-group"].length === 1
     ) {
       setDeviceGroup(selectedSlice["site-device-group"][0]);
-    } else {
-      setDeviceGroup("");
     }
   }, [slices, selectedSlice, setDeviceGroup]);
 


### PR DESCRIPTION
# Description

We don't set a device group anymore when there is more than 1 available from the list. 

Fixes #225 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
