### PR TITLE
feat: Prevent duplicated subscribers creation

### DIFF
--- a/pages/api/device-group/[name].ts
+++ b/pages/api/device-group/[name].ts
@@ -87,7 +87,7 @@ async function handleGET(req: NextApiRequest, res: NextApiResponse) {
     });
 
     if (!response.ok) {
-      res.status(response.status).json({ error: "Error retrieving network slice." });
+      res.status(response.status).json({ error: "Error retrieving device group." });
       return;
     }
 

--- a/pages/api/subscriber/[name].ts
+++ b/pages/api/subscriber/[name].ts
@@ -5,20 +5,58 @@ const WEBUI_ENDPOINT = process.env.WEBUI_ENDPOINT;
 
 export default async function handleSubscriber(req: NextApiRequest, res: NextApiResponse) {
   switch (req.method) {
+    case "GET":
+      return handleGET(req, res);
     case "POST":
       return handlePOST(req, res);
       case "DELETE":
         return handleDELETE(req, res);
     default:
-      res.setHeader("Allow", ["POST", "DELETE"]);
+      res.setHeader("Allow", ["GET", "POST", "DELETE"]);
       res.status(405).end(`Method ${req.method} Not Allowed`);
   }
 }
 
 function isValidName(name: string): boolean {
-    return /^[a-zA-Z0-9-_]+$/.test(name);
+  return /^[a-zA-Z0-9-_]+$/.test(name);
+}
+
+async function handleGET(req: NextApiRequest, res: NextApiResponse) {
+  const { name } = req.query
+
+  if (typeof name !== 'string') {
+      res.status(400).json({ error: "Invalid name provided." });
+      return;
+    }
+
+    if (!isValidName(name)) {
+      res.status(400).json({ error: "Invalid name provided." });
+      return;
+    }
+
+  const url = `${WEBUI_ENDPOINT}/api/subscriber/${name}`;
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Error getting subscriber. Error code: ${response.status}`);
+    }
+
+    const data = await response.json();
+    res.status(200).json(data);
+  } catch (error) {
+    console.error("Error details:", error);
+    res.status(500).json({
+      error: "An error occurred while retrieving the subscriber.",
+    });
   }
-  
+}
 
 async function handlePOST(req: NextApiRequest, res: NextApiResponse) {
     const { name } = req.query
@@ -52,7 +90,7 @@ async function handlePOST(req: NextApiRequest, res: NextApiResponse) {
     } catch (error) {
       console.error("Error details:", error);
       res.status(500).json({
-        error: "An error occurred while creating the subscriber",
+        error: "An error occurred while creating the subscriber.",
       });
     }
   }
@@ -84,11 +122,11 @@ async function handleDELETE(req: NextApiRequest, res: NextApiResponse) {
         throw new Error(`Error deleting subscriber. Error code: ${response.status}`);
       }
   
-      res.status(200).json({ message: "Subscriber deleted successfully" });
+      res.status(200).json({ message: "Subscriber deleted successfully." });
     } catch (error) {
       console.error("Error details:", error);
       res.status(500).json({
-        error: "An error occurred while deleting the subscriber",
+        error: "An error occurred while deleting the subscriber.",
       });
     }
   }

--- a/pages/api/subscriber/[name].ts
+++ b/pages/api/subscriber/[name].ts
@@ -18,7 +18,7 @@ export default async function handleSubscriber(req: NextApiRequest, res: NextApi
 }
 
 function isValidName(name: string): boolean {
-  return /^[a-zA-Z0-9-_]+$/.test(name);
+    return /^[a-zA-Z0-9-_]+$/.test(name);
 }
 
 async function handleGET(req: NextApiRequest, res: NextApiResponse) {

--- a/utils/createSubscriber.tsx
+++ b/utils/createSubscriber.tsx
@@ -32,9 +32,6 @@ export const createSubscriber = async ({
     if (checkResponse.ok && existingSubscriberData["AuthenticationSubscription"]["authenticationMethod"]) {
       throw new Error("Subscriber already exists.");
     }
-    else{
-      console.error(checkResponse);
-    }
 
     const response = await fetch(`/api/subscriber/imsi-${imsi}`, {
       method: "POST",
@@ -91,7 +88,7 @@ export const createSubscriber = async ({
     const details =
       error instanceof Error
         ? error.message
-        : "Failed to configure the network.";
+        : "Failed to create the subscriber.";
     throw new Error(details);
   }
 };

--- a/utils/createSubscriber.tsx
+++ b/utils/createSubscriber.tsx
@@ -28,6 +28,7 @@ export const createSubscriber = async ({
       },
     });
 
+    // Workaround for https://github.com/omec-project/webconsole/issues/109
     const existingSubscriberData = await checkResponse.json();
     if (checkResponse.ok && existingSubscriberData["AuthenticationSubscription"]["authenticationMethod"]) {
       throw new Error("Subscriber already exists.");

--- a/utils/createSubscriber.tsx
+++ b/utils/createSubscriber.tsx
@@ -21,6 +21,21 @@ export const createSubscriber = async ({
   };
 
   try {
+    const checkResponse = await fetch(`/api/subscriber/imsi-${imsi}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const existingSubscriberData = await checkResponse.json();
+    if (checkResponse.ok && existingSubscriberData["AuthenticationSubscription"]["authenticationMethod"]) {
+      throw new Error("Subscriber already exists.");
+    }
+    else{
+      console.error(checkResponse);
+    }
+
     const response = await fetch(`/api/subscriber/imsi-${imsi}`, {
       method: "POST",
       headers: {
@@ -73,6 +88,10 @@ export const createSubscriber = async ({
     return response.json();
   } catch (error) {
     console.error(error);
-    throw new Error("Failed to create the subscriber.");
+    const details =
+      error instanceof Error
+        ? error.message
+        : "Failed to configure the network.";
+    throw new Error(details);
   }
 };


### PR DESCRIPTION
# Description

We now validate whether a subscriber with the same name already exists before creating it. If it already exists, an error is displayed to the user in the creation modal.

![image](https://github.com/canonical/sdcore-nms/assets/10354025/2a48b021-a7f0-4b49-bbc9-a7961592af02)

There is an issue with the CURL GET of subscribers  (https://github.com/omec-project/webconsole/issues/109) in which an "empty" subscriber object is returned if the subscriber does not exists. So, as a workaround I added a check over one of the fields to be able to differentiate between a subscriber that exists and one that does not. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
