### PR TITLE
feat: Adding device group edition feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ yarn-error.log*
 
 # local env files
 .env*.local
+gnb_config.json
+upf_config.json
 
 # vercel
 .vercel

--- a/app/_pattern_navigation.scss
+++ b/app/_pattern_navigation.scss
@@ -113,3 +113,8 @@
 .p-side-navigation__item--title {
   white-space: nowrap;
 }
+
+.device-group-action-button {
+  color: #666;
+  font-size: small;
+}

--- a/components/DeviceGroupModal.tsx
+++ b/components/DeviceGroupModal.tsx
@@ -39,7 +39,8 @@ const ModalTitle = (networkSliceName: string | undefined, deviceGroupName: strin
   } else if (networkSliceName == undefined && deviceGroupName) {
     return "Edit Device Group: " + deviceGroupName
   } else {
-    throw new Error("Either Network Slice name or Device Group must be specified.")
+    console.error("Either Network Slice name or Device Group must be specified.")
+    return null
   }
 }
 
@@ -127,6 +128,16 @@ const DeviceGroupModal = ({
     },
   });
 
+  if (!modalTitle) {
+    return (
+      <Modal
+        title={"Error while trying to edit device group"}
+        close={toggleModal}
+      >
+        An unexpected error occurred.
+      </Modal>
+    )
+  }
   return (
     <Modal
       title={modalTitle}

--- a/components/DeviceGroupModal.tsx
+++ b/components/DeviceGroupModal.tsx
@@ -44,11 +44,7 @@ const ModalTitle = (networkSliceName: string | undefined, deviceGroupName: strin
 }
 
 const ModalButtonText = (deviceGroupName: string | undefined) => {
-  if (deviceGroupName == undefined ) {
-    return "Create"
-  } else {
-    return "Save Changes"
-  }
+  return deviceGroupName ? "Save Changes" : "Create"
 }
 
 const DeviceGroupModal = ({

--- a/components/NetworkSliceGroups.tsx
+++ b/components/NetworkSliceGroups.tsx
@@ -57,6 +57,8 @@ export const NetworkSliceGroups: React.FC<NetworkSliceTableProps> = ({
     });
   };
 
+  const [apiError, setApiError] = useState<string | null>(null);
+
   if (isLoading) {
     return <Loader text="Loading..." />;
   }
@@ -68,8 +70,7 @@ export const NetworkSliceGroups: React.FC<NetworkSliceTableProps> = ({
   const getDeleteButton = (deviceGroupName: string, subscribers: string[], sliceName: string) =>
   {
     const deleteIcon=<DeleteOutlinedIcon
-                        fontSize="small"
-                        style={{ color: "#666" }}
+                        className="device-group-action-button"
                       />
     if (subscribers &&
         subscribers.length > 0)
@@ -127,8 +128,7 @@ export const NetworkSliceGroups: React.FC<NetworkSliceTableProps> = ({
   const getEditButton = (modal_id: number) =>
     {
       const editIcon=<EditOutlinedIcon
-                        fontSize="small"
-                        style={{ color: "#666" }}
+                        className="device-group-action-button"
                       />
       return (
           <Button

--- a/components/NetworkSliceTable.tsx
+++ b/components/NetworkSliceTable.tsx
@@ -36,7 +36,7 @@ export const NetworkSliceTable: React.FC<NetworkSliceTableProps> = ({
       {isModalVisible && slice?.SliceName && (
         <DeviceGroupModal
           toggleModal={toggleModal}
-          onDeviceGroupCreated={handleDeviceGroupCreated}
+          onDeviceGroupAction={handleDeviceGroupCreated}
           networkSliceName={slice.SliceName}
         />
       )}

--- a/utils/editDeviceGroup.tsx
+++ b/utils/editDeviceGroup.tsx
@@ -1,0 +1,64 @@
+interface DeviceGroupArgs {
+  name: string;
+  ueIpPool: string;
+  dns: string;
+  mtu: number;
+  MBRUpstreamBps: number;
+  MBRDownstreamBps: number;
+}
+
+export const editDeviceGroup = async ({
+  name,
+  ueIpPool,
+  dns,
+  mtu,
+  MBRUpstreamBps,
+  MBRDownstreamBps,
+}: DeviceGroupArgs) => {
+  const deviceGroupData = {
+    "site-info": "demo",
+    "ip-domain-name": "pool1",
+    "ip-domain-expanded": {
+      dnn: "internet",
+      "ue-ip-pool": ueIpPool,
+      "dns-primary": dns,
+      mtu: mtu,
+      "ue-dnn-qos": {
+        "dnn-mbr-uplink": MBRUpstreamBps,
+        "dnn-mbr-downlink": MBRDownstreamBps,
+        "bitrate-unit": "bps",
+        "traffic-class": {
+          name: "platinum",
+          arp: 6,
+          pdb: 300,
+          pelr: 6,
+          qci: 8,
+        },
+      },
+    },
+  };
+
+  try {
+    const response = await fetch(`/api/device-group/${name}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(deviceGroupData),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Error updating device group. Error code: ${response.status}`,
+      );
+    }
+    return true;
+  } catch (error: unknown) {
+    console.error(error);
+    const details =
+      error instanceof Error
+        ? error.message
+        : "Failed to configure the network.";
+    throw new Error(details);
+  }
+};

--- a/utils/editDeviceGroup.tsx
+++ b/utils/editDeviceGroup.tsx
@@ -7,6 +7,22 @@ interface DeviceGroupArgs {
   MBRDownstreamBps: number;
 }
 
+const getDeviceGroup = async (deviceGroupName: string) => {
+  try {
+    const response = await fetch(`/api/device-group/${deviceGroupName}`, {
+      method: "GET",
+    });
+    if (!response.ok)
+      throw new Error(
+        `Failed to fetch device group. Status: ${response.status}`,
+      );
+    const deviceGroup = await response.json();
+    return deviceGroup;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
 export const editDeviceGroup = async ({
   name,
   ueIpPool,
@@ -15,30 +31,34 @@ export const editDeviceGroup = async ({
   MBRUpstreamBps,
   MBRDownstreamBps,
 }: DeviceGroupArgs) => {
-  const deviceGroupData = {
-    "site-info": "demo",
-    "ip-domain-name": "pool1",
-    "ip-domain-expanded": {
-      dnn: "internet",
-      "ue-ip-pool": ueIpPool,
-      "dns-primary": dns,
-      mtu: mtu,
-      "ue-dnn-qos": {
-        "dnn-mbr-uplink": MBRUpstreamBps,
-        "dnn-mbr-downlink": MBRDownstreamBps,
-        "bitrate-unit": "bps",
-        "traffic-class": {
-          name: "platinum",
-          arp: 6,
-          pdb: 300,
-          pelr: 6,
-          qci: 8,
+  try {
+    const currentConfig = await getDeviceGroup(name)
+    var imsis = currentConfig["imsis"]
+
+    const deviceGroupData = {
+      "site-info": "demo",
+      "imsis": imsis,
+      "ip-domain-name": "pool1",
+      "ip-domain-expanded": {
+        dnn: "internet",
+        "ue-ip-pool": ueIpPool,
+        "dns-primary": dns,
+        mtu: mtu,
+        "ue-dnn-qos": {
+          "dnn-mbr-uplink": MBRUpstreamBps,
+          "dnn-mbr-downlink": MBRDownstreamBps,
+          "bitrate-unit": "bps",
+          "traffic-class": {
+            name: "platinum",
+            arp: 6,
+            pdb: 300,
+            pelr: 6,
+            qci: 8,
+          },
         },
       },
-    },
-  };
+    };
 
-  try {
     const response = await fetch(`/api/device-group/${name}`, {
       method: "POST",
       headers: {


### PR DESCRIPTION
# Description

Adds possibility of editing existing device groups.
Device group edition modal uses the same layout as the creation modal. 
Validation is the same. 
It is not possible to edit device group name.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
