### PR TITLE
feat: Edit network slice

### DIFF
--- a/app/(network)/network-configuration/page.tsx
+++ b/app/(network)/network-configuration/page.tsx
@@ -132,7 +132,6 @@ const NetworkConfiguration = () => {
       </PageContent>
       {isCreateModalVisible && (
         <NetworkSliceModal
-          networkSlice={undefined}
           toggleModal={toggleCreateNetworkSliceModal}
         />
       )}

--- a/app/(network)/network-configuration/page.tsx
+++ b/app/(network)/network-configuration/page.tsx
@@ -7,7 +7,7 @@ import {
 } from "@canonical/react-components";
 import { deleteNetworkSlice } from "@/utils/deleteNetworkSlice";
 import { getNetworkSlices } from "@/utils/getNetworkSlices";
-import CreateNetworkSliceModal from "@/components/CreateNetworkSliceModal";
+import NetworkSliceModal from "@/components/NetworkSliceModal";
 import NetworkSliceEmptyState from "@/components/NetworkSliceEmptyState";
 import { NetworkSliceTable } from "@/components/NetworkSliceTable";
 import Loader from "@/components/Loader";
@@ -15,10 +15,13 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/utils/queryKeys";
 import PageHeader from "@/components/PageHeader";
 import PageContent from "@/components/PageContent";
+import { NetworkSlice } from "@/components/types";
 
 const NetworkConfiguration = () => {
   const queryClient = useQueryClient();
-  const [isModalVisible, setModalVisible] = useState(false);
+  const [isCreateModalVisible, setCreateModalVisible] = useState(false);
+  const [isEditModalVisible, setEditModalVisible] = useState(false);
+  const [networkSlice, setNetworkSlice] = useState<NetworkSlice | undefined>(undefined);
 
   const { data: networkSlices = [], isLoading: loading } = useQuery({
     queryKey: [queryKeys.networkSlices],
@@ -26,12 +29,25 @@ const NetworkConfiguration = () => {
   });
 
   const toggleCreateNetworkSliceModal = () =>
-    setModalVisible((prev) => !prev);
+    setCreateModalVisible((prev) => !prev);
+
+  const toggleEditNetworkSliceModal = () =>
+    setEditModalVisible((prev) => !prev);
 
   const handleConfirmDelete = async (sliceName: string) => {
     await deleteNetworkSlice(sliceName);
     void queryClient.invalidateQueries({ queryKey: [queryKeys.networkSlices] });
   };
+
+  const getEditButton = (slice: NetworkSlice) =>
+  {
+    return <Button
+              appearance=""
+              onClick={() =>{setNetworkSlice(slice); toggleEditNetworkSliceModal();}}
+              className="u-no-margin--bottom">
+              Edit
+            </Button>
+  }
 
   const getDeleteButton = (sliceName: string, deviceGroups: string[] | undefined) =>
   {
@@ -101,6 +117,7 @@ const NetworkConfiguration = () => {
                   <NetworkSliceTable slice={slice} />
                   <hr />
                   <div className="u-align--right">
+                    {getEditButton(slice)}
                     {getDeleteButton(slice.SliceName, slice["site-device-group"])}
                   </div>
                 </Card>
@@ -108,9 +125,16 @@ const NetworkConfiguration = () => {
             </>
           )}
       </PageContent>
-      {isModalVisible && (
-        <CreateNetworkSliceModal
+      {isCreateModalVisible && (
+        <NetworkSliceModal
+          networkSlice={undefined}
           toggleModal={toggleCreateNetworkSliceModal}
+        />
+      )}
+      {isEditModalVisible && (
+        <NetworkSliceModal
+          networkSlice={networkSlice}
+          toggleModal={toggleEditNetworkSliceModal}
         />
       )}
     </>

--- a/app/(network)/network-configuration/page.tsx
+++ b/app/(network)/network-configuration/page.tsx
@@ -39,11 +39,16 @@ const NetworkConfiguration = () => {
     void queryClient.invalidateQueries({ queryKey: [queryKeys.networkSlices] });
   };
 
-  const getEditButton = (slice: NetworkSlice) =>
+  const handleEditButton = (networkSlice: NetworkSlice) => {
+    setNetworkSlice(networkSlice);
+    toggleEditNetworkSliceModal();
+  }
+
+  const getEditButton = (networkSlice: NetworkSlice) =>
   {
     return <Button
               appearance=""
-              onClick={() =>{setNetworkSlice(slice); toggleEditNetworkSliceModal();}}
+              onClick={() =>{handleEditButton(networkSlice)}}
               className="u-no-margin--bottom">
               Edit
             </Button>

--- a/components/NetworkSliceEmptyState.tsx
+++ b/components/NetworkSliceEmptyState.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState } from "react";
-import CreateNetworkSliceModal from "@/components/CreateNetworkSliceModal";
+import NetworkSliceModal from "@/components/NetworkSliceModal";
 import { Button, Row, Col, Strip } from "@canonical/react-components";
 
 const NetworkSliceEmptyState = () => {
@@ -32,7 +32,8 @@ const NetworkSliceEmptyState = () => {
       </table>
 
       {isModalVisible && (
-        <CreateNetworkSliceModal
+        <NetworkSliceModal
+          networkSlice={undefined}
           toggleModal={toggleModal}
         />
       )}

--- a/components/NetworkSliceEmptyState.tsx
+++ b/components/NetworkSliceEmptyState.tsx
@@ -33,7 +33,6 @@ const NetworkSliceEmptyState = () => {
 
       {isModalVisible && (
         <NetworkSliceModal
-          networkSlice={undefined}
           toggleModal={toggleModal}
         />
       )}

--- a/components/NetworkSliceModal.tsx
+++ b/components/NetworkSliceModal.tsx
@@ -61,8 +61,6 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
       .required("Selecting at least 1 gNodeB is required."),
   });
 
-  const sliceUpf: UpfItem = {hostname: networkSlice?.["site-info"]["upf"]["upf-name"] || "", port:networkSlice?.["site-info"]["upf"]["upf-port"] || ""};
-  
   const modalTitle = (networkSliceName: string | undefined) => {
     if (networkSliceName) {
       return "Edit Network Slice: " + networkSliceName
@@ -75,32 +73,20 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
     return networkSlice ? "Edit" : "Create"
   }
 
-  const getNetworkSliceUpfs = () => {
+  const getUpfFromNetworkSlice = () => {
     if (networkSlice) {
-      return {hostname: networkSlice?.["site-info"]["upf"]["upf-name"] || "", port:networkSlice?.["site-info"]["upf"]["upf-port"] || ""};
+      return {hostname: networkSlice?.["site-info"]["upf"]["upf-name"] || "", port: networkSlice?.["site-info"]["upf"]["upf-port"] || ""};
     } else {
-      return {} as UpfItem
+      return {} as UpfItem;
     }
   }
-
-  const getUpfString = () => {
-    return networkSlice ? `${formik.values.upf.hostname}:${formik.values.upf.port}` : ""
-  }
-
-  const stringgnb = networkSlice?.["site-info"].gNodeBs?.map((item) =>{
-    return `${item.name}:${item.tac}`
-  });
-
-  const getGnbString = () => {
-    return networkSlice ? stringgnb : ""
-  } 
 
   const formik = useFormik<NetworkSliceValues>({
     initialValues: {
       mcc: networkSlice?.["site-info"]["plmn"].mcc || "",
       mnc: networkSlice?.["site-info"]["plmn"].mnc || "",
       name: networkSlice?.SliceName || "",
-      upf: getNetworkSliceUpfs(),
+      upf: getUpfFromNetworkSlice(),
       gnbList: networkSlice?.["site-info"].gNodeBs || [],
     },
     validationSchema: NetworkSliceSchema,
@@ -183,6 +169,16 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
     void formik.setFieldValue("gnbList", items);
   };
 
+  const getGnbListValueAsString = () => {
+    return (formik.values.gnbList.map((item) =>{
+      return `${item.name}:${item.tac}`
+    }));
+  };
+
+  const getUpfValueAsString = () => {
+    return formik.values.upf.hostname ? `${formik.values.upf.hostname}:${formik.values.upf.port}` : "";
+  };
+
   return (
     <Modal
       title={modalTitle(networkSlice?.SliceName)}
@@ -249,11 +245,11 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
           error={formik.touched.mnc ? formik.errors.mnc : null}
         />
         <Select
-          defaultValue={getUpfString()}
           id="upf"
           label="UPF"
           stacked
           required
+          value = {getUpfValueAsString()}
           onChange={handleUpfChange}
           options={[
             {
@@ -269,9 +265,9 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
         />
         <Select
           id="gnb"
-          defaultValue={getGnbString()}
           stacked
           required
+          value = {getGnbListValueAsString()}
           options={[
             {
               value: "",

--- a/components/NetworkSliceModal.tsx
+++ b/components/NetworkSliceModal.tsx
@@ -101,7 +101,7 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
       mnc: networkSlice?.["site-info"]["plmn"].mnc || "",
       name: networkSlice?.SliceName || "",
       upf: getNetworkSliceUpfs(),
-      gnbList: [],
+      gnbList: networkSlice?.["site-info"].gNodeBs || [],
     },
     validationSchema: NetworkSliceSchema,
     onSubmit: async (values) => {
@@ -222,7 +222,7 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
           placeholder="default"
           stacked
           required
-          disabled={networkSlice}
+          disabled={networkSlice ? true : false}
           {...formik.getFieldProps("name")}
           error={formik.touched.name ? formik.errors.name : null}
         />

--- a/components/NetworkSliceModal.tsx
+++ b/components/NetworkSliceModal.tsx
@@ -26,7 +26,7 @@ interface NetworkSliceValues {
 }
 
 interface NetworkSliceModalProps {
-  networkSlice: NetworkSlice | undefined;
+  networkSlice?: NetworkSlice;
   toggleModal: () => void;
 }
 
@@ -61,21 +61,17 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
       .required("Selecting at least 1 gNodeB is required."),
   });
 
-  const modalTitle = (networkSliceName: string | undefined) => {
-    if (networkSliceName) {
-      return "Edit Network Slice: " + networkSliceName
-    } else {
-      return "Create Network Slice"
-    }
+  const modalTitle = () => {
+      return networkSlice?.SliceName ? ("Edit Network Slice: " + networkSlice.SliceName) : "Create Network Slice"
   }
 
-  const buttonText = (networkSlice: NetworkSlice | undefined) => {
+  const buttonText = () => {
     return networkSlice ? "Edit" : "Create"
   }
 
   const getUpfFromNetworkSlice = () => {
     if (networkSlice) {
-      return {hostname: networkSlice?.["site-info"]["upf"]["upf-name"] || "", port: networkSlice?.["site-info"]["upf"]["upf-port"] || ""};
+      return {hostname: networkSlice["site-info"]["upf"]["upf-name"], port: networkSlice["site-info"]["upf"]["upf-port"]};
     } else {
       return {} as UpfItem;
     }
@@ -181,7 +177,7 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
 
   return (
     <Modal
-      title={modalTitle(networkSlice?.SliceName)}
+      title={modalTitle()}
       close={toggleModal}
       buttonRow={
         <ActionButton
@@ -191,7 +187,7 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
           disabled={!(formik.isValid && formik.dirty)}
           loading={formik.isSubmitting}
         >
-          {buttonText(networkSlice)}
+          {buttonText()}
         </ActionButton>
       }
     >

--- a/components/NetworkSliceModal.tsx
+++ b/components/NetworkSliceModal.tsx
@@ -71,12 +71,8 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
     }
   }
 
-  const modalButtonText = (networkSlice: NetworkSlice | undefined) => {
-    if (networkSlice) {
-      return "Edit"
-    } else {
-      return "Create"
-    }
+  const buttonText = (networkSlice: NetworkSlice | undefined) => {
+    return networkSlice ? "Edit" : "Create"
   }
 
   const getNetworkSliceUpfs = () => {
@@ -86,14 +82,9 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
       return {} as UpfItem
     }
   }
-  const upfsItem :UpfItem =getNetworkSliceUpfs()
 
   const getUpfString = () => {
-    if (networkSlice) {
-      return `${formik.values.upf.hostname}:${formik.values.upf.port}`
-    } else {
-      return ""
-    }
+    return networkSlice ? `${formik.values.upf.hostname}:${formik.values.upf.port}` : ""
   }
 
   const stringgnb = networkSlice?.["site-info"].gNodeBs?.map((item) =>{
@@ -101,11 +92,7 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
   });
 
   const getGnbString = () => {
-    if (networkSlice) {
-      return stringgnb
-    } else {
-      return ""
-    }
+    return networkSlice ? stringgnb : ""
   } 
 
   const formik = useFormik<NetworkSliceValues>({
@@ -113,7 +100,7 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
       mcc: networkSlice?.["site-info"]["plmn"].mcc || "",
       mnc: networkSlice?.["site-info"]["plmn"].mnc || "",
       name: networkSlice?.SliceName || "",
-      upf: upfsItem,//{} as UpfItem,//sliceUpf,//{} as UpfItem,
+      upf: getNetworkSliceUpfs(),
       gnbList: [],
     },
     validationSchema: NetworkSliceSchema,
@@ -208,7 +195,7 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
           disabled={!(formik.isValid && formik.dirty)}
           loading={formik.isSubmitting}
         >
-          {modalButtonText(networkSlice)}
+          {buttonText(networkSlice)}
         </ActionButton>
       }
     >

--- a/components/types.tsx
+++ b/components/types.tsx
@@ -12,8 +12,11 @@ export type NetworkSlice = {
       mcc: string;
       mnc: string;
     };
-    gNodeBs?: [];
-    upf: {
+    gNodeBs?: [{
+      name: string;
+      tac: number;
+    }];
+    "upf": {
       "upf-name": string;
       "upf-port": string;
     };

--- a/utils/editNetworkSlice.tsx
+++ b/utils/editNetworkSlice.tsx
@@ -1,0 +1,72 @@
+interface GnbItem {
+    name: string;
+    tac: number;
+  }
+  
+  interface EditNetworkSliceArgs {
+    name: string;
+    mcc: string;
+    mnc: string;
+    upfName: string;
+    upfPort: string;
+    gnbList: GnbItem[];
+  }
+  
+  export const editNetworkSlice = async ({
+    name,
+    mcc,
+    mnc,
+    upfName,
+    upfPort,
+    gnbList,
+  }: EditNetworkSliceArgs) => {
+  
+    try {
+      const checkResponse = await fetch(`/api/network-slice/${name}`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+  
+      if (!checkResponse.ok) {
+        throw new Error("Error editing Network Slice" + name);
+      }
+
+      var slice = await checkResponse.json();
+      slice["site-info"]["plmn"].mcc = mcc
+      slice["site-info"]["plmn"].mnc = mnc
+      slice["site-info"]["gNodeBs"] = gnbList
+      slice["site-info"]["upf"]["upf-name"] = upfName
+      slice["site-info"]["upf"]["upf-port"] = upfPort
+  
+      const networksliceResponse = await fetch(`/api/network-slice/${name}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(slice),
+      });
+  
+      if (!networksliceResponse.ok) {
+        const result = await networksliceResponse.json();
+        if (result.error) {
+          throw new Error(result.error);
+        }
+        debugger;
+        throw new Error(
+          `Error creating network. Error code: ${networksliceResponse.status}`,
+        );
+      }
+  
+      return networksliceResponse.json();
+    } catch (error: unknown) {
+      console.error(error);
+      const details =
+        error instanceof Error
+          ? error.message
+          : "Failed to configure the network.";
+      throw new Error(details);
+    }
+  };
+  

--- a/utils/editNetworkSlice.tsx
+++ b/utils/editNetworkSlice.tsx
@@ -30,7 +30,11 @@ interface GnbItem {
       });
   
       if (!checkResponse.ok) {
-        throw new Error("Error editing Network Slice" + name);
+        const result = await checkResponse.json();
+        if (result.error) {
+          throw new Error(result.error);
+        }
+        throw new Error("Error editing Network Slice " + name);
       }
 
       var slice = await checkResponse.json();
@@ -55,7 +59,7 @@ interface GnbItem {
         }
         debugger;
         throw new Error(
-          `Error creating network. Error code: ${networksliceResponse.status}`,
+          `Error editing network. Error code: ${networksliceResponse.status}`,
         );
       }
   

--- a/utils/queryKeys.tsx
+++ b/utils/queryKeys.tsx
@@ -4,5 +4,4 @@ export const queryKeys = {
   subscribers: "subscribers",
   upfList: "upf-list",
   gnbList: "gnb-list",
-  networkSlice: "network-slice"
 };

--- a/utils/queryKeys.tsx
+++ b/utils/queryKeys.tsx
@@ -4,4 +4,5 @@ export const queryKeys = {
   subscribers: "subscribers",
   upfList: "upf-list",
   gnbList: "gnb-list",
+  networkSlice: "network-slice"
 };


### PR DESCRIPTION
# Description

Adds the possibility to edit network slices.
Takes advantage of the existing Create Network Slice Modals and change the display of the fields according to the action (create or edit)
The fields in the modal are pre filled with the values of the Network Slices.
REST PATCH method does not work in the webui so I am getting the Network Slice object, modifying the new field values and POST it again. 
It is not possible to edit the name of the Network Slice

![image](https://github.com/canonical/sdcore-nms/assets/10354025/5a18ad20-fbde-4033-9e2f-7b216b0033ab)

![image](https://github.com/canonical/sdcore-nms/assets/10354025/fd8f6540-1d3c-4d68-b794-6a253ae77938)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
