### PR TITLE
fix:  null error when deleting subscriber

### DIFF
--- a/utils/deleteSubscriber.tsx
+++ b/utils/deleteSubscriber.tsx
@@ -54,7 +54,7 @@ export const deleteSubscriber = async (imsi: string) => {
 
         const deviceGroup = await deviceGroupResponse.json();
 
-        if (deviceGroup.imsis.includes(imsi)) {
+        if (deviceGroup.imsis?.includes(imsi)) {
           deviceGroup.imsis = deviceGroup.imsis.filter(
             (id: string) => id !== imsi,
           );


### PR DESCRIPTION
# Description

fix https://github.com/canonical/sdcore-nms/issues/412 


The `imsis` field of a new NS that has never had a subscriber associated  is `null`
When a NS has already had a subscriber associated the field is `[]`
We were assuming that this field was always `[]` so it failed trying to access a `null` value. In consequence the subscriber was not entirely deleted.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
