### PR TITLE
fix: run CI workflows when a PR is created

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,10 @@
 name: Main branch CI
 
 on:
+  pull_request:
+    branches:
+      - main
+
   push:
   schedule:
     - cron: "0 0 * * 0"
@@ -10,6 +14,7 @@ jobs:
     uses: ./.github/workflows/lint-report.yaml
 
   build:
+    needs: lint-report
     uses: ./.github/workflows/build.yaml
 
   integration-tests:


### PR DESCRIPTION
# Description

Workflows for main branch CI does not run when a PR is opened. This will fix the issue.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
