### PR TITLE
fix: use newer skopeo

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -12,6 +12,8 @@ jobs:
 
       - uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
+        with:
+          rockcraft-channel: edge
 
       - name: Import the image to Docker registry
         run: |

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -13,13 +13,9 @@ jobs:
       - uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
 
-      - name: Install Skopeo
-        run: |
-          sudo apt install -y skopeo
-
       - name: Import the image to Docker registry
         run: |
-          sudo skopeo --insecure-policy copy oci-archive:${{ steps.rockcraft.outputs.rock }} docker-daemon:sdcore-nms:0.1
+          sudo docker run quay.io/skopeo/stable:latest --insecure-policy copy oci-archive:${{ steps.rockcraft.outputs.rock }} docker-daemon:sdcore-nms:0.1
 
       - name: Run the image
         run: |

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install Skopeo
         run: |
-          sudo snap install skopeo --edge --devmode
+          sudo apt install -y skopeo
 
       - name: Import the image to Docker registry
         run: |

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Import the image to Docker registry
         run: |
-          sudo docker run quay.io/skopeo/stable:latest --insecure-policy copy oci-archive:${{ steps.rockcraft.outputs.rock }} docker-daemon:sdcore-nms:0.1
+          sudo rockcraft.skopeo --insecure-policy copy oci-archive:${{ steps.rockcraft.outputs.rock }} docker-daemon:sdcore-nms:0.1
 
       - name: Run the image
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install skopeo
         run: |
-          sudo snap install --devmode --channel edge skopeo
+          sudo apt install =y skopeo
       - name: Install yq
         run: |
           sudo snap install yq

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,12 +26,13 @@ jobs:
 
       - name: Import
         run: |
+          sudo snap install rockcraft --edge --classic
           image_name="$(yq '.name' rockcraft.yaml)"
           echo "image_name=${image_name}" >> $GITHUB_ENV
           version="$(yq '.version' rockcraft.yaml)"
           echo "version=${version}" >> $GITHUB_ENV
           rock_file=$(ls *.rock | tail -n 1)
-          sudo docker run quay.io/skopeo/stable:latest \
+          sudo rockcraft.skopeo \
             --insecure-policy \
             copy \
             oci-archive:"${rock_file}" \

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,9 +17,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install skopeo
-        run: |
-          sudo apt install =y skopeo
       - name: Install yq
         run: |
           sudo snap install yq
@@ -34,7 +31,7 @@ jobs:
           version="$(yq '.version' rockcraft.yaml)"
           echo "version=${version}" >> $GITHUB_ENV
           rock_file=$(ls *.rock | tail -n 1)
-          sudo skopeo \
+          sudo docker run quay.io/skopeo/stable:latest \
             --insecure-policy \
             copy \
             oci-archive:"${rock_file}" \


### PR DESCRIPTION
# Description

The version of skopeo that is delivered in the snap has not been updated since 2019. Recently, jobs that use skopeo have been failing with the following message:

`writing blob: saving image to docker engine: client version 1.22 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version`
# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code.
N/A I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [X] I validated that new and existing unit tests pass locally with my changes.
N/A Any dependent changes have been merged and published in downstream modules.
