### PR TITLE
fix: updating instructions to use rockcraft.skopeo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,13 +56,14 @@ npm run build
 Pack the rock
 
 ```bash
+sudo snap install rockcraft --edge --classic
 rockcraft pack -v
 ```
 
 Move the rock to Docker's registry
 
 ```bash
-sudo skopeo --insecure-policy copy oci-archive:sdcore-nms_0.2.0_amd64.rock docker-daemon:sdcore-nms:0.2.0
+sudo rockcraft.skopeo --insecure-policy copy oci-archive:sdcore-nms_0.2.0_amd64.rock docker-daemon:sdcore-nms:0.2.0
 ```
 
 Run the NMS


### PR DESCRIPTION
# Description

Rockcraft now ships an updated version of skopeo that works with docker 1.24 and higher

# Checklist:

- [X] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [X] I have performed a self-review of my own code.
- [X] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [X] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
