### PR TITLE
fix: workaround for edit NS bug

### DIFF
--- a/components/NetworkSliceModal.tsx
+++ b/components/NetworkSliceModal.tsx
@@ -226,6 +226,7 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
           placeholder="001"
           stacked
           required
+          disabled={networkSlice ? true : false} // Workaround for https://github.com/omec-project/webconsole/issues/200
           {...formik.getFieldProps("mcc")}
           error={formik.touched.mcc ? formik.errors.mcc : null}
         />
@@ -237,6 +238,7 @@ const NetworkSliceModal = ({ networkSlice, toggleModal }: NetworkSliceModalProps
           placeholder="01"
           stacked
           required
+          disabled={networkSlice ? true : false} // Workaround for https://github.com/omec-project/webconsole/issues/200
           {...formik.getFieldProps("mnc")}
           error={formik.touched.mnc ? formik.errors.mnc : null}
         />


### PR DESCRIPTION
# Description

Modifying the MNC or the MCC fields of a Network Slice creates a duplicate subscriber (unexpected behavior). https://github.com/omec-project/webconsole/issues/200

This workaround disables the possibility of editing the MNC and MCC fields of a network slice. 

Editing the gNB or the UPF works fine. 

Edit Network Slice Modal:

![image](https://github.com/user-attachments/assets/3975b726-4cc7-402a-81a5-0127bf8a43bc)
Create Network Slice Modal: (no changes here) 

![image](https://github.com/user-attachments/assets/80144345-ece5-4d5a-88f7-6cc8597214de)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
