### PR TITLE
fix: re enable API link to swagger UI

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -103,7 +103,8 @@ const Navigation: FC = () => {
                   <li className="p-side-navigation__item">
                     <a
                       className="p-side-navigation__link"
-                      href="#"
+                      href="/api"
+                      target="_blank"
                       rel="noreferrer"
                       title="API"
                     >

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -33,7 +33,7 @@ parts:
     plugin: go
     source: https://github.com/omec-project/webconsole.git
     source-type: git
-    source-tag: v1.4.2
+    source-tag: v1.4.3
     build-snaps:
       - go/1.21/stable
     go-buildtags:


### PR DESCRIPTION
# Description

The swagger UI API link was disabled, while waiting for the upstream webconsole implementation to be merged (https://github.com/omec-project/webconsole/pull/193) 

This PR re enables the link and update the upstream webconsole version.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
