### PR TITLE
fix: Fixes the value of the Slice Differentiator to represent a valid 24-bit int

### DIFF
--- a/utils/createNetworkSlice.tsx
+++ b/utils/createNetworkSlice.tsx
@@ -27,7 +27,7 @@ export const createNetworkSlice = async ({
   const sliceData = {
     "slice-id": {
       sst: "1",
-      sd: "010203",
+      sd: "102030",
     },
     "site-device-group": [deviceGroupName],
     "site-info": {


### PR DESCRIPTION
# Description

Value of the Slice Differentiator (SD) needs to represent a 24-bit integer and needs to have an even number of digits. 
This PR fixes the default value of the SD.

In the longer run both SD and SST should probably be configurable.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
