### PR TITLE
feat: local development for NMS after combination with webui

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,22 +5,38 @@
 
 To make contributions to this project, make sure you have [`Nodejs 18`](https://nodejs.org/) installed.
 
-1. Clone the repository:
+1. Clone the NSM and the Webui repositories:
 
    ```shell
    git clone git@github.com:canonical/sdcore-nms.git
    ```
 
-2. Navigate to the project directory:
+   ```shell
+   git clone git@github.com:omec-project/webconsole.git
+   ```
+
+2. Navigate to the NMS project directory:
 
    ```shell
    cd sdcore-nms
    ```
 
-3. Install the dependencies:
+3. Update the config file on `./example/webuicfg.yaml` with the DB information:
 
    ```shell
-   npm install
+  mongodb:
+    name: <common_db_name>
+    url: <common_db_url>
+    authKeysDbName: <auth_db_name>
+    authUrl: <auth_db_name>
+    webuiDbName: <webui_db_name>
+    webuiDbUrl: <webui_db_name>
+   ```
+
+4. Run the project
+
+   ```shell
+   make NMS_REPO_PATH=<path/to/the/NMS> WEBUI_REPO_PATH=<path/to/the/Webui>
    ```
 
 4. Run the development server:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,19 +24,32 @@ Ensure you have [`Nodejs 18`](https://nodejs.org/), Go installed, and access to 
 
 ## Development Setup
 
-Create a webui configuration file. You can use `./example/webuicfg.yaml` as an example (DB information needs to be updated):
+Create a webui configuration file. You can use `./example/webuicfg.yaml` as an example:
 
    ```yaml
-   mongodb:
-      name: <common_db_name>
-      url: <mongodb://localhost:27017/common_db_name>
-      authKeysDbName: <auth_db_name>
-      authUrl: <mongodb://localhost:27017/auth_db_name>
+   configuration:
+      managedByConfigPod:
+         enabled: true
+         syncUrl: ""
+      mongodb:
+         name: <common_db_name>
+         url: <common_db_url>
+         authKeysDbName: <auth_db_name>
+         authUrl: <auth_db_name>
+      spec-compliant-sdf: false
+   info:
+      description: WebUI initial local configuration
+      version: 1.0.0
+   ```
+
+Install NMS dependecies:
+   ```shell
+   npm ci
    ```
 
 ## Running the Project
 
-Run the project:
+To run the project, execute the following command:
 
    ```shell
    make WEBUI_REPO_PATH=<path/to/the/Webui> CONFIG_FILE_PATH=<path/to/config/file>
@@ -76,7 +89,7 @@ This command will automatically create an `./out` directory with the NMS static 
 
 ## Container image
 
-Pack the rock
+Pack the rock:
 
 ```bash
 sudo snap install rockcraft --edge --classic

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,13 +39,7 @@ To make contributions to this project, make sure you have [`Nodejs 18`](https://
    make NMS_REPO_PATH=<path/to/the/NMS> WEBUI_REPO_PATH=<path/to/the/Webui>
    ```
 
-4. Run the development server:
-
-   ```bash
-   npm run dev
-   ```
-
-Open [http://localhost:3000](http://localhost:3000) with your browser to view the changes.
+Open [http://localhost:5000](http://localhost:5000) with your browser to view the changes.
 
 ## Testing
 
@@ -67,6 +61,8 @@ To build the project:
 npm run build
 ```
 
+This command will automatically create the `./out` directory with the NMS static files.
+
 ## Container image
 
 Pack the rock
@@ -79,13 +75,13 @@ rockcraft pack -v
 Move the rock to Docker's registry
 
 ```bash
-sudo rockcraft.skopeo --insecure-policy copy oci-archive:sdcore-nms_0.2.0_amd64.rock docker-daemon:sdcore-nms:0.2.0
+sudo rockcraft.skopeo --insecure-policy copy oci-archive:sdcore-nms_<version>_amd64.rock docker-daemon:sdcore-nms:<version>
 ```
 
 Run the NMS
 
 ```bash
-docker run -p 3000:3000 sdcore-nms:0.2.0
+docker run -p 3000:3000 sdcore-nms:<version>
 ```
 
 You will have the NMS available in `http://localhost:3000`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,12 @@
 # Contributing
 
+The NMS consists of both a backend and a frontend component. You need to set up and run both to contribute effectively to the project.
 
-## Development
+## Getting Started
 
-To make contributions to this project, make sure you have [`Nodejs 18`](https://nodejs.org/) installed.
+Ensure you have [`Nodejs 18`](https://nodejs.org/), Go installed, and access to a MongoDB instance.
 
-1. Clone the NSM and the Webui repositories:
+1. Clone the NMS and the Webui repositories:
 
    ```shell
    git clone git@github.com:canonical/sdcore-nms.git
@@ -21,25 +22,35 @@ To make contributions to this project, make sure you have [`Nodejs 18`](https://
    cd sdcore-nms
    ```
 
-3. Update the config file on `./example/webuicfg.yaml` with the DB information:
+## Development Setup
 
-   ```shell
-  mongodb:
-    name: <common_db_name>
-    url: <common_db_url>
-    authKeysDbName: <auth_db_name>
-    authUrl: <auth_db_name>
-    webuiDbName: <webui_db_name>
-    webuiDbUrl: <webui_db_name>
+Create a webui configuration file. You can use `./example/webuicfg.yaml` as an example (DB information needs to be updated):
+
+   ```yaml
+   mongodb:
+      name: <common_db_name>
+      url: <mongodb://localhost:27017/common_db_name>
+      authKeysDbName: <auth_db_name>
+      authUrl: <mongodb://localhost:27017/auth_db_name>
    ```
 
-4. Run the project
+## Running the Project
+
+Run the project:
 
    ```shell
-   make NMS_REPO_PATH=<path/to/the/NMS> WEBUI_REPO_PATH=<path/to/the/Webui>
+   make WEBUI_REPO_PATH=<path/to/the/Webui> CONFIG_FILE_PATH=<path/to/config/file>
    ```
 
-Open [http://localhost:5000](http://localhost:5000) with your browser to view the changes.
+Both `WEBUI_REPO_PATH` and `CONFIG_FILE_PATH` are optional parameters:
+- `WEBUI_REPO_PATH`: Absolute path to the Webui repository. If not provided, the default value` ./../webconsole` will be used.
+- `CONFIG_FILE_PATH`: Absolute path to the Webui configuration file. If not provided, the default value `./example/webuicfg.yaml` will be used.
+
+You can omit these variables if the default paths are correct for your environment.
+
+Once the project is running, open [http://localhost:5000](http://localhost:5000) in your browser to view the changes.
+
+You will need to run this command after every modification to the NMS code. Changes will not be automatically reflected in your web browser.
 
 ## Testing
 
@@ -58,10 +69,10 @@ npm run lint
 To build the project:
 
 ```shell
-npm run build
+make build-nms
 ```
 
-This command will automatically create the `./out` directory with the NMS static files.
+This command will automatically create an `./out` directory with the NMS static files.
 
 ## Container image
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+NMS_REPO_PATH ?= /path/to/nms/repo
+WEBUI_REPO_PATH ?= /path/to/webui/repo
+CONFIG_FILE_PATH ?= $(NMS_REPO_PATH)/example/webuicfg.yaml
+
+all: clean build-node copy-files copy-config build-webui run-webui
+
+build-node:
+	@echo "Building NMS project..."
+	cd $(NMS_REPO_PATH) && npm install && npm run build
+
+
+copy-files:
+	@echo "Copying generated files to the webui repo..."
+	cp -r $(NMS_REPO_PATH)/out/* $(WEBUI_REPO_PATH)/ui/frontend_files/
+
+copy-config:
+	@echo "Copying config file to webui repo..."
+	cp $(CONFIG_FILE_PATH) $(WEBUI_REPO_PATH)/config/webuicfg.yaml
+
+build-webui:
+	@echo "Building webui project..."
+	cd $(WEBUI_REPO_PATH) && make webconsole-ui
+
+run-webui:
+	@echo "Launching webconsole-ui..."
+	cd $(WEBUI_REPO_PATH) && ./bin/webconsole-ui
+
+clean:
+	@echo "Cleaning generated files..."
+	rm -rf $(NMS_REPO_PATH)/out/*
+	rm -rf $(WEBUI_REPO_PATH)/ui/frontend_files/*
+	rm -f $(WEBUI_REPO_PATH)/config/webuicfg.yaml
+
+.PHONY: all build-node copy-files copy-config build-webui run-webui clean

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,14 @@
-NMS_REPO_PATH ?= /path/to/nms/repo
-WEBUI_REPO_PATH ?= /path/to/webui/repo
+NMS_REPO_PATH = $(CURDIR)
+WEBUI_REPO_PATH ?= $(CURDIR)/../webconsole
 CONFIG_FILE_PATH ?= $(NMS_REPO_PATH)/example/webuicfg.yaml
 
-all: clean build-node copy-files copy-config build-webui run-webui
+all: clean build-nms copy-ui-files copy-config build-webui run-webui
 
-build-node:
+build-nms:
 	@echo "Building NMS project..."
 	cd $(NMS_REPO_PATH) && npm install && npm run build
 
-
-copy-files:
+copy-ui-files:
 	@echo "Copying generated files to the webui repo..."
 	cp -r $(NMS_REPO_PATH)/out/* $(WEBUI_REPO_PATH)/ui/frontend_files/
 
@@ -31,4 +30,4 @@ clean:
 	rm -rf $(WEBUI_REPO_PATH)/ui/frontend_files/*
 	rm -f $(WEBUI_REPO_PATH)/config/webuicfg.yaml
 
-.PHONY: all build-node copy-files copy-config build-webui run-webui clean
+.PHONY: all build-nms copy-ui-files copy-config build-webui run-webui clean

--- a/README.md
+++ b/README.md
@@ -2,15 +2,17 @@
 
 A Network Management System for managing the Aether SD-Core 5G core network.
 
+The NMS is a component that provides a user interface (UI) for configuring the 5G core network in Aether SD-Core.
+
 ![Screenshot](images/nms_screenshot.png)
 
 ## Usage
 
 NMS needs to be configured with the following environment variables:
-- `WEBUI_ENDPOINT`: The endpoint of the webui. This is used to redirect the swagger operations to the webui.
+- `WEBUI_ENDPOINT`: The endpoint of the webui. This is used to redirect the swagger operations to the webui. If not set, `localhost:5000` will be used.
 
 ```console
-export WEBUI_ENDPOINT=10.1.182.28:5000
+export WEBUI_ENDPOINT=<webui_ip>:5000
 
 docker pull ghcr.io/canonical/sdcore-nms:<version>
 docker run -it --env WEBUI_ENDPOINT ghcr.io/canonical/sdcore-nms:<version>

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A Network Management System for managing the Aether SD-Core 5G core network.
 
-The NMS is a component that provides a user interface (UI) for configuring the 5G core network in Aether SD-Core.
-
 ![Screenshot](images/nms_screenshot.png)
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ NMS needs to be configured with the following environment variables:
 ```console
 export WEBUI_ENDPOINT=10.1.182.28:5000
 
-docker pull ghcr.io/canonical/sdcore-nms:0.2.0
-docker run -it --env WEBUI_ENDPOINT ghcr.io/canonical/sdcore-nms:0.2.0
+docker pull ghcr.io/canonical/sdcore-nms:<version>
+docker run -it --env WEBUI_ENDPOINT ghcr.io/canonical/sdcore-nms:<version>
 ```

--- a/example/webuicfg.yaml
+++ b/example/webuicfg.yaml
@@ -7,10 +7,7 @@ configuration:
     url: <common_db_url>
     authKeysDbName: <auth_db_name>
     authUrl: <auth_db_name>
-    webuiDbName: <webui_db_name>
-    webuiDbUrl: <webui_db_name>
   spec-compliant-sdf: false
-  enableAuthentication: true
 info:
   description: WebUI initial local configuration
   version: 1.0.0

--- a/example/webuicfg.yaml
+++ b/example/webuicfg.yaml
@@ -1,0 +1,16 @@
+configuration:
+  managedByConfigPod:
+    enabled: true
+    syncUrl: ""
+  mongodb:
+    name: <common_db_name>
+    url: <common_db_url>
+    authKeysDbName: <auth_db_name>
+    authUrl: <auth_db_name>
+    webuiDbName: <webui_db_name>
+    webuiDbUrl: <webui_db_name>
+  spec-compliant-sdf: false
+  enableAuthentication: true
+info:
+  description: WebUI initial local configuration
+  version: 1.0.0


### PR DESCRIPTION
# Description
WIP
Feedback is more than welcome
(I haven't taken a look to the docker part but I think it does not work)

This is a first attempt to automate the local development over the NMS, without having to build a rock and deploy it on a charm.

In order to have a local NMS running we need:
- Build the NMS
- Copy the static files to a specific directory on the webui
- Build the webui
- Run the webui

The idea is to be able to locally work on the NMS without having to manually run each step every time a change is made.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
