### PR TITLE
fix: Use the right MTU for the common use case by default

### DIFF
--- a/components/DeviceGroupModal.tsx
+++ b/components/DeviceGroupModal.tsx
@@ -88,7 +88,7 @@ const DeviceGroupModal = ({
       name: deviceGroup?.["group-name"] || "",
       ueIpPool: deviceGroup?.["ip-domain-expanded"]?.["ue-ip-pool"] || "",
       dns: deviceGroup?.["ip-domain-expanded"]?.["dns-primary"] || "8.8.8.8",
-      mtu: deviceGroup?.["ip-domain-expanded"]?.["mtu"] || 1460,
+      mtu: deviceGroup?.["ip-domain-expanded"]?.["mtu"] || 1456,
       MBRDownstreamMbps: deviceGroup?.["ip-domain-expanded"]?.["ue-dnn-qos"]?.["dnn-mbr-downlink"] / 1_000_000 || null,
       MBRUpstreamMbps: deviceGroup?.["ip-domain-expanded"]?.["ue-dnn-qos"]?.["dnn-mbr-uplink"] / 1_000_000 || null,
     },
@@ -195,7 +195,7 @@ const DeviceGroupModal = ({
           type="number"
           id="mtu"
           label="MTU"
-          defaultValue={1460}
+          defaultValue={1456}
           stacked
           required
           {...formik.getFieldProps("mtu")}

--- a/utils/createNetworkSlice.tsx
+++ b/utils/createNetworkSlice.tsx
@@ -51,7 +51,7 @@ export const createNetworkSlice = async ({
       dnn: "internet",
       "ue-ip-pool": "172.250.1.0/16",
       "dns-primary": "8.8.8.8",
-      mtu: 1460,
+      mtu: 1456,
       "ue-dnn-qos": {
         "dnn-mbr-uplink": 20 * 1000000,
         "dnn-mbr-downlink": 200 * 1000000,


### PR DESCRIPTION
# Description

The previous MTU of 1460 was just a bit too big for the most common setup of running over Ethernet with a standard MTU of 1500. Changing the default to 1456 prevents the UE from sending packets that would need fragmentation.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
