### PR TITLE
chore: disable password change button for admin user

### DIFF
--- a/app/(nms)/users/page.tsx
+++ b/app/(nms)/users/page.tsx
@@ -59,6 +59,7 @@ export default function Users() {
                 onClick: () => setModalData({ user: user, type: "delete" })
               }, {
                 children: "Change password",
+                disabled: user.role == 1,
                 onClick: () => setModalData({ user: user, type: "change password" })
               }
             ]} hasToggleIcon />,


### PR DESCRIPTION
# Description

https://github.com/canonical/sdcore-nms-k8s-operator/pull/359 enables authentication in the NMS charm. The charm creates an admin user and stores its username and password in a Juju secret. If the admin's password is updated using the NMS UI, the charm will loose the admin user's credentials and it will not be able to operate over the webconsole. 

**This is not a final solution to the problem.**

### Before
The button to change password is enabled:
![image](https://github.com/user-attachments/assets/dae4cf58-8832-491a-9132-12bf92c72ae3)

### After
The button to change password is disabled for the admin user:
![image](https://github.com/user-attachments/assets/b383c92e-94c8-4f44-91f9-65163c23c702)

The button to change password is enabled for the not admin user:
![image](https://github.com/user-attachments/assets/55e4e8e0-62e8-4e35-8c3f-f680afa8af2b)



# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
