### PR TITLE
feat: support empty UPF field in NS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,15 +19,15 @@ This target will produce the webconsole binary with the static export of NMS emb
 
 ### `make rock`
 
-This target will produce a  `sdcore-nms.rock` OCI image file, which will have the webconsole binary as a service. It will use the master branch of webconsole by default.
-If you want to use a specific tag for the webconsole repo, you must switch to the branch/tag in ./build/webconsole-src
+This target will produce a `sdcore-nms.rock` OCI image file, which will have the webconsole binary as a service. It will use the master branch of webconsole by default.
+If you want to use a specific tag for the webconsole repository, you must switch to the branch/tag in ./build/webconsole-src
 
 `rockcraft` must be installed to use this option.
 
 ### `make deploy`
 
 This target will create an LXC VM called `nms`, install docker, deploy the `NMS` and `MongoDB` OCI image, create a valid config file for `NMS`, and start the program.
-After the process is done, from your host machine you can run `lxc list`, and use the IP address to connect to both mongodb and NMS. The port for NMS is `:5000` and the port for mongodb is `:27017`.
+After the process is done, from your host machine you can run `lxc list`, and use the IP address to connect to both MongoDB and NMS. The port for NMS is `:5000` and the port for MongoDB is `:27017`.
 
 `make rock` must have successfully completed and `lxd` must be installed to use this option.
 
@@ -67,7 +67,7 @@ for them are stored in the `/artifacts` folder. Any files used in the build proc
 
 ### Webconsole binary
 
-`go` and `nodejs` is required to build webconsole.
+`go` and `nodejs` are required to build webconsole.
 
 The `make webconsole` target is responsible for producing the binary that serves the NMS frontend. Once run, it will:
 
@@ -83,7 +83,7 @@ The binary will need to be run with a config file. An example is available in th
 
 `rockcraft` is required to create the OCI image.
 
-The rock can be built with `rockcraft pack`. This process will use the local NMS and a predefined tag of webconsole repo to create an OCI image. The webconsole branch/tag is defined in the `rockcraft.yaml` file.
+The rock can be built with `rockcraft pack`. This process will use the local NMS and a predefined tag of webconsole repository to create an OCI image. The webconsole branch/tag is defined in the `rockcraft.yaml` file.
 
 The `make rock` target modifies this build process by directly using the `build/webconsole-src` directory. This allows you to use a local version of webconsole in the OCI image instead of having to pull from the specified tag in `rockcraft.yaml`. This is useful if you want to test changes to the backend rather than the frontend. The process is:
 
@@ -93,7 +93,7 @@ The `make rock` target modifies this build process by directly using the `build/
 
 ## Deploy
 
-The binary requires a config file and an available mongodb deployment to operate. By default, the path for the config file is `./config/webuicfg.yaml` from the directory of the binary. The OCI image does not come with a config file preconfigured, but the repo contains an example at `examples/config/webuicfg.yaml`.
+The binary requires a config file and an available MongoDB deployment to operate. By default, the path for the config file is `./config/webuicfg.yaml` from the directory of the binary. The OCI image does not come with a config file preconfigured, but the repository contains an example at `examples/config/webuicfg.yaml`.
 
 `make deploy` takes care of quickly getting a running program. It will:
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,16 @@ A Network Management System for managing the Aether SD-Core 5G core network.
 
 ## Usage
 
-NMS needs to be configured with the following environment variables:
-- `WEBUI_ENDPOINT`: The endpoint of the webui. This is used to redirect the swagger operations to the webui.
+The NMS has a swagger UI page that rus by default on `localhost`. If the NMS will run remotely, set the following environment.
+```console
+export WEBUI_ENDPOINT=<NMS-ip>:5000
+```
+
+Run the NMS as follows:
 
 ```console
-export WEBUI_ENDPOINT=10.1.182.28:5000
-
 docker pull ghcr.io/canonical/sdcore-nms:1.1.0
-docker run -it --env WEBUI_ENDPOINT ghcr.io/canonical/sdcore-nms:1.1.0
+docker run -it --env WEBUI_ENDPOINT  -v <path-to-config-file>:/config/webuicfg.yaml -p 5000:5000 ghcr.io/canonical/sdcore-nms:1.1.0
 ```
+
+An example of the config file can be found in `examples/config/webuicfg.yaml`

--- a/components/NetworkSliceGroups.tsx
+++ b/components/NetworkSliceGroups.tsx
@@ -157,7 +157,8 @@ export const NetworkSliceGroups: React.FC<NetworkSliceTableProps> = ({
         <MainTable
           headers={[
             {
-              content: deviceGroup?.["group-name"] || "N/A",
+              content: deviceGroup?.["group-name"] || "",
+              style: { textTransform: "none" },
             },
             {
               content:
@@ -177,7 +178,7 @@ export const NetworkSliceGroups: React.FC<NetworkSliceTableProps> = ({
                   content:
                     deviceGroup?.["ip-domain-expanded"]?.[
                     "ue-ip-pool"
-                    ] || "N/A",
+                    ] || "",
 
                   className: "u-align--right",
                 },
@@ -190,7 +191,7 @@ export const NetworkSliceGroups: React.FC<NetworkSliceTableProps> = ({
                   content:
                     deviceGroup?.["ip-domain-expanded"]?.[
                     "dns-primary"
-                    ] || "N/A",
+                    ] || "",
 
                   className: "u-align--right",
                 },
@@ -203,7 +204,7 @@ export const NetworkSliceGroups: React.FC<NetworkSliceTableProps> = ({
                   content:
                     deviceGroup?.["ip-domain-expanded"]?.[
                     "mtu"
-                    ] || "N/A",
+                    ] || "",
 
                   className: "u-align--right",
                 },
@@ -222,7 +223,7 @@ export const NetworkSliceGroups: React.FC<NetworkSliceTableProps> = ({
                     "ue-dnn-qos"
                     ]?.["dnn-mbr-downlink"] / 1_000_000
                     } Mbps`
-                    : "N/A",
+                    : "",
                   className: "u-align--right",
                 },
               ],
@@ -240,7 +241,7 @@ export const NetworkSliceGroups: React.FC<NetworkSliceTableProps> = ({
                     "ue-dnn-qos"
                     ]?.["dnn-mbr-uplink"] / 1_000_000
                     } Mbps`
-                    : "N/A",
+                    : "",
                   className: "u-align--right",
                 },
               ],

--- a/components/NetworkSliceModal.tsx
+++ b/components/NetworkSliceModal.tsx
@@ -74,7 +74,10 @@ const NetworkSliceModal = ({ networkSlice, toggleModal, onSave }: NetworkSliceMo
 
   const getUpfFromNetworkSlice = () => {
     if (networkSlice) {
-      return { hostname: networkSlice["site-info"]["upf"]["upf-name"], port: networkSlice["site-info"]["upf"]["upf-port"] };
+      return {
+        hostname: networkSlice["site-info"]?.["upf"]?.["upf-name"] ?? "",
+        port: networkSlice["site-info"]?.["upf"]?.["upf-port"] ?? "",
+      };
     } else {
       return {} as UpfItem;
     }

--- a/components/NetworkSliceTable.tsx
+++ b/components/NetworkSliceTable.tsx
@@ -56,7 +56,7 @@ export const NetworkSliceTable: React.FC<NetworkSliceTableProps> = ({
             columns: [
               { content: "MCC" },
               {
-                content: slice["site-info"]?.plmn.mcc || "N/A",
+                content: slice["site-info"]?.plmn.mcc || "",
                 className: "u-align--right",
               },
             ],
@@ -66,7 +66,7 @@ export const NetworkSliceTable: React.FC<NetworkSliceTableProps> = ({
             columns: [
               { content: "MNC" },
               {
-                content: slice["site-info"]?.plmn.mnc || "N/A",
+                content: slice["site-info"]?.plmn.mnc || "",
                 className: "u-align--right",
               },
             ],
@@ -76,10 +76,14 @@ export const NetworkSliceTable: React.FC<NetworkSliceTableProps> = ({
             columns: [
               { content: "UPF" },
               {
-                content: `${slice["site-info"]?.upf?.["upf-name"] || "N/A"}:${
-                  slice["site-info"]?.upf?.["upf-port"] || "N/A"
-                }`,
-
+                content: (() => {
+                  const upfName = slice["site-info"]?.upf?.["upf-name"] ?? "";
+                  const upfPort = slice["site-info"]?.upf?.["upf-port"] ?? "";
+                  if (upfName === "" && upfPort === "") {
+                    return "";
+                  }
+                  return `${upfName}:${upfPort}`;
+                })(),
                 className: "u-align--right",
               },
             ],
@@ -90,7 +94,7 @@ export const NetworkSliceTable: React.FC<NetworkSliceTableProps> = ({
               { content: "gNodeBs" },
               {
                 content:
-                  slice?.["site-info"]?.gNodeBs?.length.toString() || "N/A",
+                  slice?.["site-info"]?.gNodeBs?.length.toString() || "0",
                 className: "u-align--right",
               },
             ],

--- a/utils/editNetworkSlice.tsx
+++ b/utils/editNetworkSlice.tsx
@@ -40,6 +40,7 @@ export const editNetworkSlice = async ({
     sliceData["site-info"]["plmn"].mcc = mcc
     sliceData["site-info"]["plmn"].mnc = mnc
     sliceData["site-info"]["gNodeBs"] = gnbList
+    sliceData["site-info"]["upf"] = sliceData["site-info"]["upf"] ?? {};
     sliceData["site-info"]["upf"]["upf-name"] = upfName
     sliceData["site-info"]["upf"]["upf-port"] = upfPort
 


### PR DESCRIPTION
# Description

https://github.com/omec-project/webconsole/pull/279 propagates the DELETE UPF operation to  network slices to avoid dangling references. If a UPF is removed from a NS, this field no long exists and if we try to edit the NS, the NMS crashes. This PR adds support for network slices that do not contain a "upf" field.

After this PR, the NMS no longer crashes, instead, the UPF value selected by default in the Edit modal is empty.

After this PR, the empty fields are shown as empty instead of `N/A`. Also the name of the device groups are no longer cast to capital letters.

This PR also adds minor fixes to the CONTRIBUTING.md and README.md files 

![image](https://github.com/user-attachments/assets/c076a4b8-0398-4c5b-9561-9e95b16645d0)
![image](https://github.com/user-attachments/assets/3a45d5f2-bbeb-4e04-a402-18a937085144)
![image](https://github.com/user-attachments/assets/cf2e0184-45d4-4214-9736-9118099eb0cb)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
