### PR TITLE
fix: avoid crash when fields in subscriber are missing

### DIFF
--- a/components/SubscriberModal.tsx
+++ b/components/SubscriberModal.tsx
@@ -83,9 +83,9 @@ const SubscriberModal = ({ toggleModal, subscriber, slices, deviceGroups, onSubm
   const formik = useFormik<SubscriberValues>({
     initialValues: {
       imsi: rawIMSI || "",
-      opc: subscriber?.["AuthenticationSubscription"]["opc"]["opcValue"] || "",
-      key: subscriber?.["AuthenticationSubscription"]["permanentKey"]["permanentKeyValue"] || "",
-      sequenceNumber: subscriber?.["AuthenticationSubscription"]["sequenceNumber"] || "",
+      opc: subscriber?.["AuthenticationSubscription"]?.["opc"]?.["opcValue"] ?? "",
+      key: subscriber?.["AuthenticationSubscription"]?.["permanentKey"]?.["permanentKeyValue"] ?? "",
+      sequenceNumber: subscriber?.["AuthenticationSubscription"]?.["sequenceNumber"] ?? "",
       selectedSlice: oldNetworkSliceName,
       deviceGroup: oldDeviceGroupName,
     },

--- a/utils/editSubscriber.tsx
+++ b/utils/editSubscriber.tsx
@@ -57,7 +57,7 @@ const updateSubscriber = async (subscriberData: any, token: string) => {
     var existingSubscriberData = await getSubscriberResponse.json();
     if (!getSubscriberResponse.ok ||
       (!existingSubscriberData["AuthenticationSubscription"]["authenticationMethod"] &&
-        !existingSubscriberData["AmPolicyData"]["subscCats"])) {
+        !existingSubscriberData["AccessAndMobilitySubscriptionData"]["nssai"])) {
       throw new Error("Subscriber does not exist.");
     }
 

--- a/utils/editSubscriber.tsx
+++ b/utils/editSubscriber.tsx
@@ -55,11 +55,15 @@ const updateSubscriber = async (subscriberData: any, token: string) => {
 
     // Workaround for https://github.com/omec-project/webconsole/issues/109
     var existingSubscriberData = await getSubscriberResponse.json();
-    if (!getSubscriberResponse.ok || !existingSubscriberData["AuthenticationSubscription"]["authenticationMethod"]) {
+    if (!getSubscriberResponse.ok ||
+      (!existingSubscriberData["AuthenticationSubscription"]["authenticationMethod"] &&
+        !existingSubscriberData["AmPolicyData"]["subscCats"])) {
       throw new Error("Subscriber does not exist.");
     }
 
+    existingSubscriberData["AuthenticationSubscription"]["opc"] = existingSubscriberData["AuthenticationSubscription"]["opc"] ?? {};
     existingSubscriberData["AuthenticationSubscription"]["opc"]["opcValue"] = subscriberData.opc;
+    existingSubscriberData["AuthenticationSubscription"]["permanentKey"] = existingSubscriberData["AuthenticationSubscription"]["permanentKey"] ?? {};
     existingSubscriberData["AuthenticationSubscription"]["permanentKey"]["permanentKeyValue"] = subscriberData.key;
     existingSubscriberData["AuthenticationSubscription"]["sequenceNumber"] = subscriberData.sequenceNumber;
 


### PR DESCRIPTION
# Description

The GetSubscribers operation will get the information from `subscriptionData.provisionedData.amData`.

The GET subscriber by ID operation returns an union of several DB fields. Some of them can be absent depending on the order of creation of the subscriber (first create DG and then subscriber, or the other way around).

if `subscriptionData.provisionedData.amData` exist but the others don't, the subscriber will appear in the list of subscribers and  if we try to edit it, the NMS will crash.

This PR remove the crash in case of missing `AuthenticationSubscription` fields in a Subscriber.

It modifies the workaround to identify if a Subscriber does not exist (https://github.com/omec-project/webconsole/issues/109) to check if both `AuthenticationSubscription/authenticationMethod and AccessAndMobilitySubscriptionData/nssai are missing.

### Trying to edit a Subscriber with `AuthenticationSubscription` missing fields does not crash

![image](https://github.com/user-attachments/assets/2e200ffb-aafb-471a-9c4c-64ed3ea7df41)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
