### PR TITLE
fix: backport fix subscriber modal

### DIFF
--- a/components/SubscriberModal.tsx
+++ b/components/SubscriberModal.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useMemo, useState } from "react";
 import {
   ActionButton,
   Form,
@@ -125,42 +125,26 @@ const SubscriberModal = ({ toggleModal, subscriber, slices, deviceGroups }: Prop
   });
 
   const handleSliceChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    void formik.setFieldValue("selectedSlice", e.target.value);
+    const selectedSliceName = e.target.value;
+    const selectedSlice = slices.find((slice) => slice["slice-name"] === selectedSliceName);
+    const deviceGroupOptions = selectedSlice?.["site-device-group"] || [];
+
+    formik.setValues({
+      ...formik.values,
+      selectedSlice: selectedSliceName,
+      deviceGroup: deviceGroupOptions.length > 1 ? "" : deviceGroupOptions[0] || "",
+    });
   };
 
   const handleDeviceGroupChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    void formik.setFieldValue("deviceGroup", e.target.value);
+    formik.setFieldValue("deviceGroup", e.target.value);
   };
 
-  const selectedSlice = slices.find(
-    (slice) => slice["slice-name"] === formik.values.selectedSlice,
-  );
+  const deviceGroupOptions = useMemo(() => {
+    const selectedSlice = slices.find((slice) => slice["slice-name"] === formik.values.selectedSlice);
+    return selectedSlice?.["site-device-group"] || [];
+  }, [formik.values.selectedSlice, slices]);
 
-  const setDeviceGroup = useCallback(
-    (deviceGroup: string) => {
-      if (formik.values.deviceGroup !== deviceGroup) {
-        formik.setFieldValue("deviceGroup", deviceGroup);
-      }
-    },
-    [formik],
-  );
-
-  const deviceGroupOptions = React.useMemo(() => {
-    return selectedSlice && selectedSlice["site-device-group"]
-      ? selectedSlice["site-device-group"]
-      : [];
-  }, [selectedSlice]);
-
-  useEffect(() => {
-    if (subscriber && selectedSlice && oldNetworkSliceName === selectedSlice["slice-name"]) {
-      setDeviceGroup(oldDeviceGroupName);
-    }
-    else if (selectedSlice && selectedSlice["site-device-group"]?.length === 1) {
-      setDeviceGroup(selectedSlice["site-device-group"][0]);
-    } else {
-      setDeviceGroup("");
-    }
-  }, [subscriber, selectedSlice, oldNetworkSliceName, oldDeviceGroupName, setDeviceGroup, deviceGroupOptions]);
 
   return (
     <Modal


### PR DESCRIPTION
# Description

back port https://github.com/canonical/sdcore-nms/pull/723 and a part of https://github.com/canonical/sdcore-nms/pull/707

fix for https://github.com/canonical/sdcore-nms/issues/711 and https://github.com/canonical/sdcore-nms/issues/712

Issue: we cannot create/edit subscribers in network slices that contain more than 1 device group. We are not able to select an element of the dropdown.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
