### PR TITLE
fix: reorder creation of Network slice objects

### DIFF
--- a/utils/createNetworkSlice.tsx
+++ b/utils/createNetworkSlice.tsx
@@ -75,6 +75,13 @@ export const createNetworkSlice = async ({
       throw new Error("Network slice already exists");
     }
 
+    const devicegroupResponse = await apiPostDeviceGroup(deviceGroupName, deviceGroupData, token);
+    if (!devicegroupResponse.ok) {
+      throw new Error(
+        `Error creating device group. Error code: ${devicegroupResponse.status}`,
+      );
+    }
+
     const updateNetworkSliceResponse = await apiPostNetworkSlice(name, sliceData, token);
     if (!updateNetworkSliceResponse.ok) {
       const networkSliceData = await updateNetworkSliceResponse.json();
@@ -84,13 +91,6 @@ export const createNetworkSlice = async ({
       debugger;
       throw new Error(
         `Error creating network slice. Error code: ${updateNetworkSliceResponse.status}`,
-      );
-    }
-
-    const devicegroupResponse = await apiPostDeviceGroup(deviceGroupName, deviceGroupData, token);
-    if (!devicegroupResponse.ok) {
-      throw new Error(
-        `Error creating device group. Error code: ${devicegroupResponse.status}`,
       );
     }
 


### PR DESCRIPTION
# Description

In the webconsole, the creation of NS and DG are really tight and need an specific order. 

1. When we create a NS that contains a reference to a DG that does not exist:
    - a broken message is sent to the PCF
    - there is an error and no message is sent to the other NFs
3. When we create a DG  no message is sent to the PCF. (it's only sent on update or delete DG operation)
4. When we create a DG and there are no network slices, no message is sent to NFs.

Current behavior in the NMS when creating a NS:
- POST NS with a reference to a non-existing DG
- POST a DG associated to that NS

If we do this, we run into situation 1. and we can see the following logs, when sending the config messages to other NFs trough GRPC:

```
025-02-05T09:03:04.947Z [nms] 2025-02-05T09:03:04.947Z	INFO	server/clientEvtHandler.go:295	Did not find group mim-default 	{"component": "WebUI", "category": "GRPC", "NF": "udr-0"}
2025-02-05T09:03:04.947Z [nms] 2025-02-05T09:03:04.947Z	INFO	server/clientEvtHandler.go:704	Not sending slice config	{"component": "WebUI", "category": "GRPC", "NF": "udr-0"}
```
Then, when we create the DG object, the config message is sent to all the NFs except for the PCF. Which mean that the PCF contains a broken config until a new message is sent.

## The Fix

Reorder the objects creation to first create the DG object, and then the NS with the reference to that DG. This way no broken message is sent to the NFs. We are also sure that the config is always up to date in the NFs.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
