### PR TITLE
fix: select gnb list in Network slice modal error

### DIFF
--- a/components/NetworkSliceModal.tsx
+++ b/components/NetworkSliceModal.tsx
@@ -159,8 +159,12 @@ const NetworkSliceModal = ({ networkSlice, toggleModal, onSave }: NetworkSliceMo
   };
 
   const handleGnbChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const gnb = gnbItems.find((item: GnbItem) => e.target.value === `${item.name}:${item.tac}`);
-    void formik.setFieldValue("gnbList", [...formik.values.gnbList, gnb]);
+    const selectedValues = Array.from(e.target.selectedOptions, (option) => option.value);
+    const selectedGnbItems = selectedValues.map((value) => {
+      const [name, tac] = value.split(":");
+      return { name, tac: Number(tac) };
+    });
+    formik.setFieldValue("gnbList", selectedGnbItems);
   };
 
   const getGnbListValueAsString = () => {


### PR DESCRIPTION
# Description

This is a fix for https://github.com/canonical/sdcore-nms-k8s-operator/issues/440

**Before**: every time we clicked in a gnb option, it was added to the form values (even if it already was selected).

**Now**: we add all the selected values to the form values, they are replaced at each change. We need to use `ctrl` to select multiple gnbs. This is the behavior that we see in https://vanillaframework.io/docs/base/forms#select

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
