### PR TITLE
fix: subscriber modal size

### DIFF
--- a/app/(nms)/subscribers/modals.tsx
+++ b/app/(nms)/subscribers/modals.tsx
@@ -270,34 +270,37 @@ const SubscriberModal: React.FC<SubscriberModalProps> = ({
         <fieldset><legend></legend>
           <Row>
             <Col size={4}>* IMSI</Col>
-            <Col size={1}>
-              <div style={{ lineHeight: "36px", color: isEdit || !selectedSlice ? "#999" : "inherit"}}>
-              {
-                isEdit ?
-                  `${previousSlice?.["site-info"]?.plmn?.mcc || ""}${previousSlice?.["site-info"]?.plmn?.mnc || ""}`
-                : `${selectedSlice?.["site-info"]?.plmn?.mcc || "000"}${selectedSlice?.["site-info"]?.plmn?.mnc || "00"}`
-              }
-              </div>
+            <Col size={8}>
+              <Row className="p-form__control" style={{ display : "flex" }}>
+                <Col size={2}>
+                  <label className="p-form__label" style={{color: isEdit || !selectedSlice ? "#999" : "inherit"}}>
+                  {
+                    isEdit ?
+                      `${previousSlice?.["site-info"]?.plmn?.mcc || ""}${previousSlice?.["site-info"]?.plmn?.mnc || ""}`
+                    : `${selectedSlice?.["site-info"]?.plmn?.mcc || "000"}${selectedSlice?.["site-info"]?.plmn?.mnc || "000"}`
+                  }
+                  </label>
+                </Col>
+                <Col size={isEdit ? 6 : 4}>
+                  <Input
+                    id="msin"
+                    type="text"
+                    required
+                    disabled={isEdit}
+                    placeholder="0100007487"
+                    {...formik.getFieldProps("msin")}
+                    error={formik.touched.msin && formik.errors.msin ? formik.errors.msin : imsiError }
+                  />
+                </Col>
+                {!isEdit ? 
+                  <Col size={2}><div className="u-align--right">
+                    <Button appearance="positive" type="button" onClick={handleGenerateImsi} >
+                      Generate
+                    </Button>
+                </div></Col> : null
+                }
+              </Row>
             </Col>
-            <Col size={isEdit ? 7 : 5}>
-            <Input
-              id="msin"
-              type="text"
-              required
-              stacked
-              disabled={isEdit}
-              placeholder="0100007487"
-              {...formik.getFieldProps("msin")}
-              error={formik.touched.msin && formik.errors.msin ? formik.errors.msin : imsiError }
-            />
-            </Col> 
-            {!isEdit ? 
-              <Col size={2}><div className="u-align--right">
-                <Button appearance="positive" type="button" onClick={handleGenerateImsi} >
-                  Generate
-                </Button>
-              </div></Col> : null
-            }
           </Row>
         </fieldset>
         <fieldset><legend>Authentication</legend>


### PR DESCRIPTION
# Description

In the previous version, there was a lot of extra (unnecessary) space in the input fields of the modal.
This PR reduces this space.
The use of `label` instead of just `div` for the plmnID helps with the alignment.

The key to solve this problem : `style={{ display : "flex" }}`

![image](https://github.com/user-attachments/assets/65314cc5-88ee-4659-b712-07720ced84e3)
![image](https://github.com/user-attachments/assets/63107b62-80d7-4a33-bc96-21f483604da4)


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
