### PR TITLE
fix: handle 404 no found and 409 conflict errrors during subscriber operations

### DIFF
--- a/app/(nms)/subscribers/modals.tsx
+++ b/app/(nms)/subscribers/modals.tsx
@@ -411,10 +411,10 @@ export function EditSubscriberModal({ subscriber, token, closeFn }: editSubscrib
       sequenceNumber: values.sequenceNumber
     }
     await editSubscriber({
-      subscriberData: subscriberAuthData,
+      imsi: subscriberAuthData.rawImsi,
       previousDeviceGroup: subscriber.deviceGroupName,
       newDeviceGroupName: values.deviceGroupName,
-      token: token,
+      token: token
     });
   };
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -39,7 +39,7 @@ parts:
     plugin: go
     source: https://github.com/omec-project/webconsole.git
     source-type: git
-    source-tag: v1.8.3
+    source-tag: v1.8.4
     build-snaps:
       - go/1.21/stable
     go-buildtags:

--- a/utils/errors.tsx
+++ b/utils/errors.tsx
@@ -24,6 +24,11 @@ export function is404NotFoundError(error: Error | unknown): boolean {
   return (error instanceof WebconsoleApiError && error.status === 404);
 }
 
+export function is409ConflictError(error: Error | unknown): boolean {
+  return (error instanceof WebconsoleApiError && error.status === 409);
+}
+
+
 export class OperationError extends Error {
 
   constructor(message: string) {

--- a/utils/subscriberOperations.tsx
+++ b/utils/subscriberOperations.tsx
@@ -130,8 +130,7 @@ async function getSubscriberAuthData(ueId: string, token: string): Promise<Subsc
     const rawImsi = ueId.split("-")[1];
     const response = await apiGetSubscriber(rawImsi, token);
     if (!response.ok) {
-      console.error(`Error retrieving subscriber data for ${rawImsi}: ${response.status}`);
-      throw new WebconsoleApiError(response.status, `Error retrieving subscriber data from for Imsi ${rawImsi}`);
+      throw new WebconsoleApiError(response.status, `Error retrieving subscriber data for Imsi ${rawImsi}`);
     }
     const subscriberData: SubscriberData = await response.json();
     if (!subscriberData || !subscriberData.ueId || !subscriberData.AuthenticationSubscription) {
@@ -167,14 +166,15 @@ export async function filterSubscribers(subscribers: string[], token: string): P
 async function doesSubscriberExist(rawImsi: string, token: string) : Promise<boolean>{
   try {
     const response = await apiGetSubscriber(rawImsi, token);
-    return response.ok;
-  } catch (error) {
-
-    if (is404NotFoundError(error)) {
+    if (response.ok) {
+      return true;
+    } else if (response.status === 404) {
       return false;
+    } else {
+      throw new WebconsoleApiError(response.status, `Error retrieving subscriber data for Imsi ${rawImsi}`);
     }
-
-    console.error("Error retrieving subscribers:", error);
+  } catch (error) {
+    console.error("Error retrieving subscriber:", error);
     throw error;
   }
 }

--- a/utils/subscriberOperations.tsx
+++ b/utils/subscriberOperations.tsx
@@ -32,30 +32,13 @@ async function apiGetSubscriber(rawImsi: string, token: string): Promise<Respons
     throw new OperationError(`Error getting subscriber: Invalid imsi provided ${rawImsi}.`);
   }
   try {
-    const response = await fetch(`/api/subscriber/imsi-${rawImsi}`, {
+    return await fetch(`/api/subscriber/imsi-${rawImsi}`, {
       method: "GET",
       headers: {
         "Authorization": "Bearer " + token,
         "Content-Type": "application/json",
       },
     });
-
-    if (response.status === 404) {
-      throw new WebconsoleApiError(404, "Subscriber not found");
-    }
-
-    if (!response.ok) {
-      var respData;
-      try {
-        respData = await response.json();
-      } catch {
-        respData = { error: "Malformed JSON response" };
-      }
-      throw new WebconsoleApiError(response.status, respData.error || "Unknown error");
-    }
-
-    return response;
-
   } catch (error) {
     console.error(`Error retrieving subscriber ${rawImsi}: ${error}`);
     throw error;
@@ -75,19 +58,9 @@ async function apiPostSubscriber(rawImsi: string, subscriberData: SubscriberAuth
       },
       body: JSON.stringify(subscriberData),
     });
-
-    if (response.status === 409) {
-      throw new WebconsoleApiError(409, "Subscriber already exists");
-    }
-
     if (!response.ok) {
-      var respData;
-      try {
-        respData = await response.json();
-      } catch {
-        respData = { error: "Malformed JSON response" };
-      }
-      throw new WebconsoleApiError(response.status, respData.error || "Unknown error");
+      const respData = await response.json();
+      throw new WebconsoleApiError(response.status, respData.error);
     }
   } catch (error) {
     console.error(`Error in POST subscriber ${rawImsi}: ${error}`);
@@ -156,13 +129,16 @@ async function getSubscriberAuthData(ueId: string, token: string): Promise<Subsc
   try {
     const rawImsi = ueId.split("-")[1];
     const response = await apiGetSubscriber(rawImsi, token);
-    const subscriber = await response.json();
-    if (!subscriber) {
-      console.error(`Subscriber data is null or undefined for IMSI ${rawImsi}`);
-      throw new Error(`Empty subscriber data for IMSI ${rawImsi}`);
+    if (!response.ok) {
+      console.error(`Error retrieving subscriber data for ${rawImsi}: ${response.status}`);
+      throw new WebconsoleApiError(response.status, `Error retrieving subscriber data from for Imsi ${rawImsi}`);
+    }
+    const subscriberData: SubscriberData = await response.json();
+    if (!subscriberData || !subscriberData.ueId || !subscriberData.AuthenticationSubscription) {
+      console.error(`Subscriber data is invalid for IMSI ${rawImsi}`);
+      throw new Error(`Invalid subscriber data for IMSI ${rawImsi}`);
     }
 
-    const subscriberData = subscriber as SubscriberData;
     const subscriberAuthData : SubscriberAuthData = {
       rawImsi: subscriberData.ueId.split("-")[1],
       opc: subscriberData.AuthenticationSubscription?.opc?.opcValue ?? "",
@@ -171,11 +147,7 @@ async function getSubscriberAuthData(ueId: string, token: string): Promise<Subsc
     }
     return subscriberAuthData;
   } catch (error) {
-    if (is404NotFoundError(error)) {
-      console.error(`Subscriber with IMSI ${ueId.split("-")[1]} does not exist.`);
-      throw error
-    }
-    console.error(`Error retrieving subscriber ${ueId}: ${error}`);
+    console.error(`Error retrieving subscriber authentication data for ${ueId}: ${error}`);
     throw error;
   }
 };
@@ -219,24 +191,22 @@ export async function createSubscriber({
   token
 }: CreateSubscriberArgs) : Promise<void> {
   try {
-    const exists = await doesSubscriberExist(subscriberData.rawImsi, token);
-    if (exists){
-      throw new OperationError(`Subscriber with IMSI ${subscriberData.rawImsi} already exists.`);
+    var existingDeviceGroupData = await getDeviceGroup(deviceGroupName, token);
+    try {
+      await apiPostSubscriber(subscriberData.rawImsi, subscriberData, token);
+    } catch (error) {
+      if (is409ConflictError(error)) {
+        throw new OperationError(`Subscriber with IMSI ${subscriberData.rawImsi} already exists.`);
+      }
+      throw error;
     }
 
-    var existingDeviceGroupData = await getDeviceGroup(deviceGroupName, token);
-    await apiPostSubscriber(subscriberData.rawImsi, subscriberData, token);
     if (!existingDeviceGroupData["imsis"].includes(subscriberData.rawImsi)) {
       existingDeviceGroupData["imsis"].push(subscriberData.rawImsi);
     }
     await apiPostDeviceGroup(deviceGroupName, existingDeviceGroupData, token);
 
   } catch (error) {
-    if (is409ConflictError(error)) {
-      console.debug(`Subscriber with IMSI ${subscriberData.rawImsi} already exists.`);
-      throw error;
-    }
-
     console.error(`Failed to create subscriber ${subscriberData.rawImsi} : ${error}`);
     throw error;
   }
@@ -244,33 +214,33 @@ export async function createSubscriber({
 
 
 interface EditSubscriberArgs {
-  subscriberData: SubscriberAuthData;
+  imsi: string;
   previousDeviceGroup: string;
   newDeviceGroupName: string;
-  token: string
+  token: string;
 }
 
 export async function editSubscriber({
-  subscriberData,
+  imsi,
   previousDeviceGroup,
   newDeviceGroupName,
   token
 }: EditSubscriberArgs) : Promise<void> {
   try {
     var newDeviceGroupData = await getDeviceGroup(newDeviceGroupName, token);
-    const exists = await doesSubscriberExist(subscriberData.rawImsi, token);
+    const exists = await doesSubscriberExist(imsi, token);
     if (!exists){
       throw new OperationError("Subscriber does not exist.");
     }
     if (previousDeviceGroup != newDeviceGroupName) {
-      await updatePreviousDeviceGroup(subscriberData.rawImsi, previousDeviceGroup, token);
+      await updatePreviousDeviceGroup(imsi, previousDeviceGroup, token);
     }
-    if (!newDeviceGroupData.imsis.includes(subscriberData.rawImsi)) {
-      newDeviceGroupData.imsis.push(subscriberData.rawImsi);
+    if (!newDeviceGroupData.imsis.includes(imsi)) {
+      newDeviceGroupData.imsis.push(imsi);
     }
     await apiPostDeviceGroup(newDeviceGroupName, newDeviceGroupData, token);
   } catch (error) {
-    console.error(`Failed to edit subscriber ${subscriberData.rawImsi} : ${error}`);
+    console.error(`Failed to edit subscriber ${imsi} : ${error}`);
     throw error;
   }
 };

--- a/utils/subscriberOperations.tsx
+++ b/utils/subscriberOperations.tsx
@@ -1,5 +1,5 @@
 import { apiPostDeviceGroup, getDeviceGroup, getDeviceGroups } from "@/utils/deviceGroupOperations";
-import {is404NotFoundError, is409ConflictError, OperationError, WebconsoleApiError} from "@/utils/errors";
+import {is404NotFoundError, is409ConflictError, OperationError, WebconsoleApiError } from "@/utils/errors";
 import { DeviceGroup, SubscriberAuthData, SubscriberData, SubscriberId, SubscriberTableData } from "@/components/types";
 
 

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -28,6 +28,7 @@ export const HTTPStatus = (code: number): string => {
     const map: { [key: number]: string } = {
         400: "Bad Request",
         401: "Unauthorized",
+        409: "Conflict",
         403: "Forbidden",
         404: "Not Found",
         500: "Internal Server Error",


### PR DESCRIPTION
# Description

The backend started to throw `Not Found Error` if subscriber does not exist and `Conflict Error` if subscriber already Exist within the following PRs:
https://github.com/omec-project/webconsole/pull/318
https://github.com/omec-project/webconsole/pull/317

This PR handles those errors in the frontend which are throwed by backend.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
