### PR TITLE
chore: show the subscribers in ascending order according to IMSIs

### DIFF
--- a/app/(nms)/subscribers/page.tsx
+++ b/app/(nms)/subscribers/page.tsx
@@ -105,7 +105,8 @@ export default function Subscribers() {
     );
   }
 
-  const tableContent: MainTableRow[] = subscribers.map((subscriber) => {
+  const sortedSubscribers = [...subscribers].sort((a, b) => a.rawImsi.localeCompare(b.rawImsi));
+  const tableContent: MainTableRow[] = sortedSubscribers.map((subscriber) => {
     return {
       key: subscriber.rawImsi,
       columns: [
@@ -153,8 +154,6 @@ export default function Subscribers() {
       </PageHeader>
       <PageContent colSize={8}>
         <MainTable
-          defaultSort='"abcd"'
-          defaultSortDirection="ascending"
           headers={[
             { content: "IMSI" },
             { content: "Network Slice" },


### PR DESCRIPTION
# Description

This PR orders the subscribers according to their IMSI numbers in ascending order.

Fixes: https://github.com/canonical/sdcore-nms/issues/508

![image](https://github.com/user-attachments/assets/f5935d8d-af11-4970-a7db-8c7ee4ed9473)


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
