### PR TITLE
feat: allow selecting only valid gNBs in network slice modal

### DIFF
--- a/app/(nms)/network-configuration/modals.tsx
+++ b/app/(nms)/network-configuration/modals.tsx
@@ -264,8 +264,8 @@ export const NetworkSliceModal: React.FC<NetworkSliceModalProps> = ({
               disabled: true,
               value: "",
             },
-            ...gnbItems.map((gnb) => ({
-              label: `${gnb.name} (tac:${gnb.tac})`,
+            ...gnbItems.filter( gnb => gnb.tac ).map((gnb) => ({
+              label: `${gnb.name} (TAC: ${gnb.tac})`,
               value: `${gnb.name}:${gnb.tac}`,
             })),
           ]}

--- a/app/(nms)/network-configuration/page.tsx
+++ b/app/(nms)/network-configuration/page.tsx
@@ -101,7 +101,7 @@ export default function NetworkSlices() {
   const tableContent: MainTableRow[] = networkSlices.map((networkSlice) => {
     const upf = networkSlice["site-info"]?.["upf"];
     const gNodeBs = networkSlice["site-info"]?.gNodeBs || [];
-    const gNodeBList = [...gNodeBs.map((gNodeB, index) => `${gNodeB.name} (tac: ${gNodeB.tac})`)];
+    const gNodeBList = [...gNodeBs.map((gNodeB, index) => `${gNodeB.name} (TAC: ${gNodeB.tac})`)];
     return {
       key: networkSlice["slice-name"],
       columns: [


### PR DESCRIPTION
# Description

This PR improves the Network Slice modal by preventing the selection of invalid gNBs (those without an associated TAC).

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
