### PR TITLE
chore: bump workload to v1.8.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ export WEBUI_ENDPOINT=<NMS-ip>:5000
 Run the NMS as follows:
 
 ```console
-docker pull ghcr.io/canonical/sdcore-nms:1.1.0
-docker run -it --env WEBUI_ENDPOINT  -v <path-to-config-file>:/config/webuicfg.yaml -p 5000:5000 ghcr.io/canonical/sdcore-nms:1.1.0
+docker pull ghcr.io/canonical/sdcore-nms:1.8.5
+docker run -it --env WEBUI_ENDPOINT  -v <path-to-config-file>:/config/webuicfg.yaml -p 5000:5000 ghcr.io/canonical/sdcore-nms:1.8.5
 ```
 
 An example of the config file can be found in `examples/config/webuicfg.yaml`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdcore-nms",
-  "version": "1.1.0",
+  "version": "1.8.5",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3005",

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: sdcore-nms
 base: ubuntu@24.04
-version: "1.1.0"
+version: "1.8.5"
 summary: SD-Core NMS
 description: |
   A Network Management System for managing the SD-Core 5G core network.
@@ -39,9 +39,9 @@ parts:
     plugin: go
     source: https://github.com/omec-project/webconsole.git
     source-type: git
-    source-tag: v1.8.5
+    source-tag: v${CRAFT_PROJECT_VERSION}
     build-snaps:
-      - go/1.21/stable
+      - go/1.24/stable
     go-buildtags:
       - ui
     stage-packages:


### PR DESCRIPTION
# Description

Bump NMS workload to the latest upstream webconsole release v1.8.5.
Bump the `go` version to the same as used in the upstream project: 1.24.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
