### PR TITLE
chore: inform users on missing gNBs in Network Slice model

### DIFF
--- a/app/(nms)/inventory/gnbs_modals.tsx
+++ b/app/(nms)/inventory/gnbs_modals.tsx
@@ -19,12 +19,10 @@ interface GnbFormValues {
 
 const GnbSchema = Yup.object().shape({
     name: Yup.string()
-    .min(1)
-    .max(32, "Name must not exceed 32 characters")
-    .matches(/^[a-zA-Z][a-zA-Z0-9-_]+$/, {
+    .matches(/^[a-zA-Z][a-zA-Z0-9-_]{1,255}$/, {
     message: (
         <>
-        Name must start with a letter. <br />
+        Name must start with a letter and must not exceed 256 characters. <br />
         Only alphanumeric characters, dashes, and underscores.
         </>
     ),

--- a/app/(nms)/network-configuration/modals.tsx
+++ b/app/(nms)/network-configuration/modals.tsx
@@ -253,6 +253,7 @@ export const NetworkSliceModal: React.FC<NetworkSliceModalProps> = ({
         <Select
           id="gnbList"
           label="gNodeBs"
+          help="If gNB does not appear in the list, please check that a TAC is associated to it"
           required
           stacked
           multiple

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sdcore-nms",
-  "version": "1.1.0",
+  "version": "1.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sdcore-nms",
-      "version": "1.1.0",
+      "version": "1.8.5",
       "dependencies": {
         "@canonical/react-components": "^1.10.0",
         "@emotion/react": "^11.14.0",


### PR DESCRIPTION
# Description

This PR fixes #784 adding an helper message informing the users that a gNB may not be seen in the Network Slice modal when it has no TAC associated to it.
This PR also improves the name validation of gNBs by limiting the maximum length to 256 characters (as enforced in `webconsole` backend).

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
