### PR TITLE
fix: add help message in subscriber edit modal (network slice field)

### DIFF
--- a/app/(nms)/subscribers/modals.tsx
+++ b/app/(nms)/subscribers/modals.tsx
@@ -228,6 +228,7 @@ const SubscriberModal: React.FC<SubscriberModalProps> = ({
         <Select
           id="network-slice"
           label="Network Slice"
+          help={isEdit ? "Only network slices using compatible MCC and MNC appear in the list" : ""}
           required
           stacked
           value={formik.values.networkSliceName}


### PR DESCRIPTION
# Description

Fix https://github.com/canonical/sdcore-nms/issues/787

This PR adds a help message in the Network slice field in the edit subscriber modal, to inform that only those using compatible MCC and MNC are listed.

![image](https://github.com/user-attachments/assets/931bff63-9ed3-44dd-be97-dd1c53117546)

No changes in the create modal

![image](https://github.com/user-attachments/assets/ff904c36-7b3a-4478-8ae7-f3d94c32bcf4)


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
