### PR TITLE
feat: use custom DNN in device groups

### DIFF
--- a/app/(nms)/device-groups/modals.tsx
+++ b/app/(nms)/device-groups/modals.tsx
@@ -52,7 +52,7 @@ const DeviceGroupSchema = Yup.object().shape({
       .required("Network slice is required."),
   dnn: Yup.string()
       .min(1)
-      .max(255, "Name should not exceed 255 characters.")
+      .max(255, "DNN should not exceed 255 characters.")
       .matches(/^[a-zA-Z][a-zA-Z0-9-_]+$/, {
       message: (
         <>
@@ -93,6 +93,7 @@ interface DeviceGroupModalProps {
   title: string;
   initialValues: DeviceGroupFormValues;
   isEdit?: boolean;
+  numberOfSubscribers: number;
   onSubmit: (values: any) => void;
   closeFn: () => void
 }
@@ -101,6 +102,7 @@ export const DeviceGroupModal: React.FC<DeviceGroupModalProps> = ({
   title,
   initialValues,
   isEdit = false,
+  numberOfSubscribers,
   onSubmit,
   closeFn,
 }) => {
@@ -204,7 +206,7 @@ export const DeviceGroupModal: React.FC<DeviceGroupModalProps> = ({
           type="text"
           required
           stacked
-          disabled={isEdit}
+          disabled={isEdit && numberOfSubscribers > 0}
           placeholder="internet"
           {...formik.getFieldProps("dnn")}
           error={formik.touched.dnn ? formik.errors.dnn : null}
@@ -380,6 +382,7 @@ export function CreateDeviceGroupModal({ closeFn }: createNewDeviceGroupModalPro
       <DeviceGroupModal
         title="Create device group"
         initialValues={initialValues}
+        numberOfSubscribers={0}
         onSubmit={handleSubmit}
         closeFn={closeFn}
       />
@@ -434,6 +437,7 @@ export function EditDeviceGroupModal({ deviceGroup, closeFn }: editDeviceGroupAc
         title={"Edit device group: " + `${deviceGroup["group-name"]}`}
         initialValues={initialValues}
         isEdit={true}
+        numberOfSubscribers={deviceGroup.imsis.length}
         onSubmit={handleSubmit}
         closeFn={closeFn}
       />

--- a/app/(nms)/device-groups/modals.tsx
+++ b/app/(nms)/device-groups/modals.tsx
@@ -20,6 +20,7 @@ import * as Yup from "yup";
 interface DeviceGroupFormValues {
   name: string;
   networkSlice: string;
+  dnn: string;
   ueIpPool: string;
   dns: string;
   mtu: number;
@@ -49,6 +50,18 @@ const DeviceGroupSchema = Yup.object().shape({
   networkSlice: Yup.string()
       .min(1)
       .required("Network slice is required."),
+  dnn: Yup.string()
+      .min(1)
+      .max(255, "Name should not exceed 255 characters.")
+      .matches(/^[a-zA-Z][a-zA-Z0-9-_]+$/, {
+      message: (
+        <>
+          DNN must start with a letter. <br />
+          Only alphanumeric characters, dashes, and underscores.
+        </>
+      ),
+      })
+      .required("DNN is required"),
   ueIpPool: Yup.string()
       .required("IP pool is required")
       .test("is-cidr", "Invalid IP address pool.", (value) => value ? validateCidr(value) : false),
@@ -184,6 +197,17 @@ export const DeviceGroupModal: React.FC<DeviceGroupModalProps> = ({
                 value: networkSliceName,
             })),
           ]}
+        />
+        <Input
+          id="dnn"
+          label="DNN"
+          type="text"
+          required
+          stacked
+          disabled={isEdit}
+          placeholder="internet"
+          {...formik.getFieldProps("dnn")}
+          error={formik.touched.dnn ? formik.errors.dnn : null}
         />
         <Input
           id="ue-ip-pool"
@@ -325,6 +349,7 @@ export function CreateDeviceGroupModal({ closeFn }: createNewDeviceGroupModalPro
     const MBRDownstreamBps = Number(values.MBRDownstreamMbps) * 1_000_000;
     await createDeviceGroup({
       name: values.name,
+      dnn: values.dnn,
       ueIpPool: values.ueIpPool,
       dns: values.dns,
       mtu: values.mtu,
@@ -340,6 +365,7 @@ export function CreateDeviceGroupModal({ closeFn }: createNewDeviceGroupModalPro
   const initialValues: DeviceGroupFormValues = {
     name: "",
     networkSlice: "",
+    dnn: "",
     ueIpPool: "",
     dns: "8.8.8.8",
     mtu: 1456,
@@ -373,6 +399,7 @@ export function EditDeviceGroupModal({ deviceGroup, closeFn }: editDeviceGroupAc
     const MBRDownstreamBps = Number(values.MBRDownstreamMbps) * 1_000_000;
     await editDeviceGroup({
       name: values.name,
+      dnn: values.dnn,
       ueIpPool: values.ueIpPool,
       dns: values.dns,
       mtu: values.mtu,
@@ -391,6 +418,7 @@ export function EditDeviceGroupModal({ deviceGroup, closeFn }: editDeviceGroupAc
   const initialValues: DeviceGroupFormValues = {
     name: deviceGroup["group-name"] || "",
     networkSlice:deviceGroup["network-slice"] || "",
+    dnn: deviceGroup["ip-domain-expanded"]?.["dnn"] || "",
     ueIpPool: deviceGroup["ip-domain-expanded"]?.["ue-ip-pool"] || "",
     dns: deviceGroup["ip-domain-expanded"]?.["dns-primary"] || "8.8.8.8",
     mtu: deviceGroup["ip-domain-expanded"]?.["mtu"] || 1456,

--- a/app/(nms)/device-groups/page.tsx
+++ b/app/(nms)/device-groups/page.tsx
@@ -83,12 +83,15 @@ export default function DeviceGroups() {
       </>
     );
   }
-  const tableContent: MainTableRow[] = deviceGroups.map((deviceGroup) => {
+
+  const sortedDeviceGroups = [...deviceGroups].sort((a, b) => a["group-name"].localeCompare(b["group-name"]));
+  const tableContent: MainTableRow[] = sortedDeviceGroups.map((deviceGroup) => {
     return {
       key: deviceGroup["group-name"],
       columns: [
         { content: deviceGroup["group-name"] },
         { content: deviceGroup["network-slice"] },
+        { content: deviceGroup["ip-domain-expanded"]?.dnn },
         {
           content: deviceGroup["ip-domain-expanded"]?.["ue-ip-pool"],
           hasOverflow: true,
@@ -167,6 +170,7 @@ export default function DeviceGroups() {
           headers={[
             { content: "Name" },
             { content: "Network Slice" },
+            { content: "DNN" },
             { content: "Subscriber IP Pool" },
             {
               content: "DNS",

--- a/app/(nms)/subscribers/modals.tsx
+++ b/app/(nms)/subscribers/modals.tsx
@@ -500,6 +500,7 @@ export const DeleteSubscriberButton: React.FC<deleteSubscriberButtonProps> = ({r
 
 interface SubscriberViewValues {
   rawImsi: string;
+  dnn: string;
   opc: string;
   key: string;
   sequenceNumber: string;
@@ -521,10 +522,14 @@ export function ViewSubscriberModal({ subscriber, closeFn }: ViewSubscriberModal
         </>
       }>
       <Form>
-        <fieldset><legend>Identity</legend>
+        <fieldset>
           <ViewSubscriberRow
             fieldName="IMSI"
             fieldValue={subscriber.rawImsi}
+          />
+          <ViewSubscriberRow
+            fieldName="DNN"
+            fieldValue={subscriber.dnn}
           />
         </fieldset>
         <fieldset><legend>Authentication</legend>

--- a/app/(nms)/subscribers/modals.tsx
+++ b/app/(nms)/subscribers/modals.tsx
@@ -293,8 +293,8 @@ const SubscriberModal: React.FC<SubscriberModalProps> = ({
         <Row>
           <Col size={4}>* DNN</Col>
           <Col size={8}>{
-            formik.values.dnn.length > 50
-              ? `${formik.values.dnn.substring(0, 50)}...`
+            formik.values.dnn.length > 40
+              ? `${formik.values.dnn.substring(0, 40)}...`
               : formik.values.dnn}
           </Col>
         </Row><br></br>
@@ -560,7 +560,11 @@ export function ViewSubscriberModal({ subscriber, closeFn }: ViewSubscriberModal
           />
           <ViewSubscriberRow
             fieldName="DNN"
-            fieldValue={subscriber.dnn}
+            fieldValue={
+              subscriber.dnn.length > 40
+                ? `${subscriber.dnn.substring(0, 40)}...`
+                : subscriber.dnn
+            }
           />
         </fieldset>
         <fieldset><legend>Authentication</legend>

--- a/app/(nms)/subscribers/modals.tsx
+++ b/app/(nms)/subscribers/modals.tsx
@@ -292,7 +292,11 @@ const SubscriberModal: React.FC<SubscriberModalProps> = ({
         />
         <Row>
           <Col size={4}>* DNN</Col>
-          <Col size={8}>{formik.values.dnn}</Col>
+          <Col size={8}>{
+            formik.values.dnn.length > 50
+              ? `${formik.values.dnn.substring(0, 50)}...`
+              : formik.values.dnn}
+          </Col>
         </Row><br></br>
         <fieldset><legend>Identity</legend>
           <Row>

--- a/app/(nms)/subscribers/page.tsx
+++ b/app/(nms)/subscribers/page.tsx
@@ -114,6 +114,7 @@ export default function Subscribers() {
         { content: subscriber.rawImsi },
         { content: subscriber.networkSliceName },
         { content: subscriber.deviceGroupName },
+        { content: subscriber.dnn },
         {
           content:
             <List
@@ -188,6 +189,7 @@ export default function Subscribers() {
             { content: "IMSI" },
             { content: "Network Slice" },
             { content: "Device Group" },
+            { content: "DNN" },
             {
               content: "Actions",
               className:"u-align--right",

--- a/components/types.ts
+++ b/components/types.ts
@@ -96,6 +96,7 @@ export type SubscriberTableData = {
   sequenceNumber: string;
   networkSliceName: string;
   deviceGroupName: string;
+  dnn: string;
 }
 
 export type User = {

--- a/examples/config/webuicfg.yaml
+++ b/examples/config/webuicfg.yaml
@@ -15,69 +15,6 @@ info:
   description: WebUI initial local configuration
   version: 1.0.0
 logger:
-  AMF:
-    ReportCaller: false
-    debugLevel: info
-  AUSF:
-    ReportCaller: false
-    debugLevel: info
-  Aper:
-    ReportCaller: false
-    debugLevel: info
-  CommonConsumerTest:
-    ReportCaller: false
-    debugLevel: info
-  FSM:
-    ReportCaller: false
-    debugLevel: info
-  MongoDBLibrary:
-    ReportCaller: false
-    debugLevel: info
-  N3IWF:
-    ReportCaller: false
-    debugLevel: info
-  NAS:
-    ReportCaller: false
-    debugLevel: info
-  NGAP:
-    ReportCaller: false
-    debugLevel: info
-  NRF:
-    ReportCaller: false
-    debugLevel: info
-  NamfComm:
-    ReportCaller: false
-    debugLevel: info
-  NamfEventExposure:
-    ReportCaller: false
-    debugLevel: info
-  NsmfPDUSession:
-    ReportCaller: false
-    debugLevel: info
-  NudrDataRepository:
-    ReportCaller: false
-    debugLevel: info
-  OpenApi:
-    ReportCaller: false
-    debugLevel: info
-  PCF:
-    ReportCaller: false
-    debugLevel: info
-  PFCP:
-    ReportCaller: false
-    debugLevel: info
-  PathUtil:
-    ReportCaller: false
-    debugLevel: info
-  SMF:
-    ReportCaller: false
-    debugLevel: info
-  UDM:
-    ReportCaller: false
-    debugLevel: info
-  UDR:
-    ReportCaller: false
-    debugLevel: info
   WEBUI:
     ReportCaller: false
     debugLevel: info

--- a/utils/deviceGroupOperations.ts
+++ b/utils/deviceGroupOperations.ts
@@ -266,6 +266,23 @@ export async function getDeviceGroup(deviceGroupName: string, token: string): Pr
   }
 };
 
+export async function getDeviceGroupDnns(token: string): Promise<Record<string, string>> {
+  try {
+    const deviceGroupNames = await apiGetAllDeviceGroupNames(token);
+    const entries = await Promise.all(
+      deviceGroupNames.map(async (groupName: string) => {
+        const deviceGroup = await getDeviceGroup(groupName, token);
+        return [groupName, deviceGroup["ip-domain-expanded"]?.dnn || ""] as [string, string];
+      })
+    );
+
+    return Object.fromEntries(entries);
+  } catch (error) {
+    console.error(`Failed to get DeviceGroup DNN map: ${error}`);
+    throw error;
+  }
+}
+
 const findDeviceGroupNetworkSlice = (deviceGroupName: string, networkSlices: NetworkSlice[]): string => {
   for (const networkSlice of networkSlices) {
     if (networkSlice["site-device-group"] && networkSlice["site-device-group"].includes(deviceGroupName)) {

--- a/utils/deviceGroupOperations.ts
+++ b/utils/deviceGroupOperations.ts
@@ -82,6 +82,7 @@ export async function apiPostDeviceGroup(name: string, deviceGroupData: any, tok
 
 interface CreateDeviceGroupArgs {
   name: string;
+  dnn: string;
   ueIpPool: string;
   dns: string;
   mtu: number;
@@ -95,6 +96,7 @@ interface CreateDeviceGroupArgs {
 
 export async function createDeviceGroup({
   name,
+  dnn,
   ueIpPool,
   dns,
   mtu,
@@ -116,7 +118,7 @@ export async function createDeviceGroup({
     "imsis": [],
     "ip-domain-name": "pool1",
     "ip-domain-expanded": {
-      dnn: "internet",
+      dnn: dnn,
       "ue-ip-pool": ueIpPool,
       "dns-primary": dns,
       mtu: mtu,
@@ -164,6 +166,7 @@ export async function createDeviceGroup({
 
 interface EditDeviceGroupArgs {
   name: string;
+  dnn: string;
   ueIpPool: string;
   dns: string;
   mtu: number;
@@ -176,6 +179,7 @@ interface EditDeviceGroupArgs {
 
 export async function editDeviceGroup({
   name,
+  dnn,
   ueIpPool,
   dns,
   mtu,
@@ -199,7 +203,7 @@ export async function editDeviceGroup({
       "imsis": imsis,
       "ip-domain-name": "pool1",
       "ip-domain-expanded": {
-        dnn: "internet",
+        dnn: dnn,
         "ue-ip-pool": ueIpPool,
         "dns-primary": dns,
         mtu: mtu,

--- a/utils/subscriberOperations.ts
+++ b/utils/subscriberOperations.ts
@@ -98,7 +98,7 @@ export async function getSubscribersTableData(token: string): Promise<Subscriber
       subscriberNames.map(async (subscriber: SubscriberId) => {
         const subscriberAuthData = await getSubscriberAuthData(subscriber.ueId, token);
         const parents = findDeviceGroupByImsi(subscriber.ueId.split("-")[1], deviceGroups);
-          return { ...subscriberAuthData, networkSliceName: parents?.networkSliceName || "", deviceGroupName: parents?.deviceGroupName || "" };
+          return { ...subscriberAuthData, dnn: parents?.dnn || "", networkSliceName: parents?.networkSliceName || "", deviceGroupName: parents?.deviceGroupName || "" };
         })
       );
     return allSubscribers.filter((item) => item !== undefined);
@@ -112,10 +112,11 @@ export async function getSubscribersTableData(token: string): Promise<Subscriber
 const findDeviceGroupByImsi = (
   rawImsi: string,
   deviceGroups: DeviceGroup[]
-): { deviceGroupName: string; networkSliceName: string } | null => {
+): { dnn: string; deviceGroupName: string; networkSliceName: string } | null => {
   for (const deviceGroup of deviceGroups) {
     if (deviceGroup.imsis && deviceGroup.imsis.includes(rawImsi)) {
       return {
+        dnn : deviceGroup["ip-domain-expanded"]?.dnn ?? "",
         deviceGroupName: deviceGroup["group-name"],
         networkSliceName: deviceGroup["network-slice"] ?? ""
       };


### PR DESCRIPTION
# Description
This PR is the implementation of the feature that allows the operator to set a custom name for the DNN in the device groups.
Before it was hardcoded to `internet`


## Create device group modal
<img width="739" height="752" alt="image" src="https://github.com/user-attachments/assets/5c5695e4-d86d-4857-9d44-b29762a7d071" />

## Edit device group modal
- DNN is editable if the Device group does not contain subscribers

<img width="683" height="497" alt="image" src="https://github.com/user-attachments/assets/a7eab528-0be5-4e41-a3a0-4821e24b1d8f" />

- DNN is not editable if the Device group contains subscribers
<img width="685" height="496" alt="image" src="https://github.com/user-attachments/assets/161d0d37-3506-4ce4-9224-f5d7b7c08b62" />

## Device group table
<img width="1563" height="436" alt="image" src="https://github.com/user-attachments/assets/9313813f-174e-4400-8e80-798427a5256f" />

## Create subscriber modal
Automatically fills the DNN value when selecting a device group
<img width="1002" height="434" alt="image" src="https://github.com/user-attachments/assets/2466f44b-9c54-4a3a-a291-f6f7e6053606" />

## Edit subscriber modal
Is prefilled with the DNN of the selected device group and updated accordingly
<img width="919" height="487" alt="image" src="https://github.com/user-attachments/assets/0395f4b2-30e9-4601-92e8-036ebcc74180" />

## View subscriber modal

<img width="903" height="401" alt="image" src="https://github.com/user-attachments/assets/aca2bc3c-48df-46a2-b86a-a208a533d804" />


## Subscribers table
<img width="1333" height="389" alt="image" src="https://github.com/user-attachments/assets/982ee509-7d0b-461e-aecd-84cee95c2279" />

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
